### PR TITLE
Add initial Obsidian plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -521,3 +521,18 @@ RAG_RETRIEVAL_K=4
 ```
 
 ## 🤖 Interactive Research Agent
+
+## 🧩 Obsidian Plugin
+
+A minimal plugin is provided in `obsidian-plugin/thoth-obsidian`. To build the plugin and load it into Obsidian:
+
+1. Install dependencies and compile the TypeScript:
+   ```bash
+   cd obsidian-plugin/thoth-obsidian
+   npm install
+   npm run build
+   ```
+2. Copy the generated files (`manifest.json`, `main.js`, `styles.css`) to your Obsidian vault's `plugins/thoth-obsidian` folder.
+3. Enable **Thoth Research Assistant** in Obsidian's community plugins settings.
+
+Once enabled you can configure API keys and start the `thoth agent` process directly from Obsidian.

--- a/obsidian-plugin/thoth-obsidian/main.js
+++ b/obsidian-plugin/thoth-obsidian/main.js
@@ -1,0 +1,150 @@
+import { Modal, Notice, Plugin, PluginSettingTab, Setting } from 'obsidian';
+import { spawn } from 'child_process';
+import * as fs from 'fs';
+import * as path from 'path';
+const DEFAULT_SETTINGS = {
+    mistralKey: '',
+    openrouterKey: '',
+    endpointHost: 'localhost',
+    endpointPort: '8000',
+};
+export default class ThothPlugin extends Plugin {
+    constructor() {
+        super(...arguments);
+        this.process = null;
+    }
+    async onload() {
+        await this.loadSettings();
+        this.addSettingTab(new ThothSettingTab(this.app, this));
+        this.addCommand({
+            id: 'start-thoth-agent',
+            name: 'Start Agent',
+            callback: () => this.startAgent(),
+        });
+        this.addCommand({
+            id: 'open-thoth-chat',
+            name: 'Open Chat',
+            callback: () => this.openChat(),
+        });
+    }
+    onunload() {
+        if (this.process) {
+            this.process.kill();
+        }
+    }
+    async loadSettings() {
+        this.settings = Object.assign({}, DEFAULT_SETTINGS, await this.loadData());
+    }
+    async saveSettings() {
+        await this.saveData(this.settings);
+        const envPath = path.join(this.app.vault.adapter.getBasePath(), '.env');
+        const lines = [
+            `API_MISTRAL_KEY=${this.settings.mistralKey}`,
+            `API_OPENROUTER_KEY=${this.settings.openrouterKey}`,
+            `ENDPOINT_HOST=${this.settings.endpointHost}`,
+            `ENDPOINT_PORT=${this.settings.endpointPort}`,
+        ];
+        fs.writeFileSync(envPath, lines.join('\n'), 'utf8');
+    }
+    startAgent() {
+        if (this.process) {
+            new Notice('Agent already running');
+            return;
+        }
+        const cmd = 'thoth';
+        const args = ['agent'];
+        this.process = spawn(cmd, args, {
+            cwd: this.app.vault.adapter.getBasePath(),
+        });
+        this.process.stdout.on('data', (data) => {
+            console.log('thoth:', data.toString());
+        });
+        this.process.stderr.on('data', (data) => {
+            console.error('thoth:', data.toString());
+        });
+        this.process.on('close', () => {
+            this.process = null;
+        });
+        new Notice('Thoth agent started');
+    }
+    openChat() {
+        new ChatModal(this.app, this).open();
+    }
+}
+class ThothSettingTab extends PluginSettingTab {
+    constructor(app, plugin) {
+        super(app, plugin);
+        this.plugin = plugin;
+    }
+    display() {
+        const { containerEl } = this;
+        containerEl.empty();
+        new Setting(containerEl)
+            .setName('Mistral API Key')
+            .addText((text) => text
+            .setPlaceholder('Enter Mistral API key')
+            .setValue(this.plugin.settings.mistralKey)
+            .onChange(async (value) => {
+            this.plugin.settings.mistralKey = value;
+            await this.plugin.saveSettings();
+        }));
+        new Setting(containerEl)
+            .setName('OpenRouter API Key')
+            .addText((text) => text
+            .setPlaceholder('Enter OpenRouter API key')
+            .setValue(this.plugin.settings.openrouterKey)
+            .onChange(async (value) => {
+            this.plugin.settings.openrouterKey = value;
+            await this.plugin.saveSettings();
+        }));
+        new Setting(containerEl)
+            .setName('Endpoint Host')
+            .addText((text) => text
+            .setPlaceholder('localhost')
+            .setValue(this.plugin.settings.endpointHost)
+            .onChange(async (value) => {
+            this.plugin.settings.endpointHost = value;
+            await this.plugin.saveSettings();
+        }));
+        new Setting(containerEl)
+            .setName('Endpoint Port')
+            .addText((text) => text
+            .setPlaceholder('8000')
+            .setValue(this.plugin.settings.endpointPort)
+            .onChange(async (value) => {
+            this.plugin.settings.endpointPort = value;
+            await this.plugin.saveSettings();
+        }));
+        new Setting(containerEl)
+            .setName('Start Agent')
+            .addButton((btn) => btn.setButtonText('Start').onClick(() => {
+            this.plugin.startAgent();
+        }));
+    }
+}
+class ChatModal extends Modal {
+    constructor(app, plugin) {
+        super(app);
+        this.plugin = plugin;
+    }
+    onOpen() {
+        const { contentEl } = this;
+        this.outputEl = contentEl.createDiv({ cls: 'thoth-output' });
+        const inputWrapper = contentEl.createDiv();
+        this.inputEl = inputWrapper.createEl('input', { type: 'text' });
+        inputWrapper.createEl('button', { text: 'Send' }).onclick = () => this.sendInput();
+    }
+    sendInput() {
+        if (!this.plugin.process) {
+            new Notice('Agent not running');
+            return;
+        }
+        const text = this.inputEl.value;
+        this.plugin.process.stdin.write(text + '\n');
+        this.inputEl.value = '';
+    }
+    onClose() {
+        const { contentEl } = this;
+        contentEl.empty();
+    }
+}

--- a/obsidian-plugin/thoth-obsidian/main.ts
+++ b/obsidian-plugin/thoth-obsidian/main.ts
@@ -1,0 +1,195 @@
+import { App, Modal, Notice, Plugin, PluginSettingTab, Setting } from 'obsidian';
+import { spawn, ChildProcessWithoutNullStreams } from 'child_process';
+import * as fs from 'fs';
+import * as path from 'path';
+
+interface ThothPluginSettings {
+  mistralKey: string;
+  openrouterKey: string;
+  endpointHost: string;
+  endpointPort: string;
+}
+
+const DEFAULT_SETTINGS: ThothPluginSettings = {
+  mistralKey: '',
+  openrouterKey: '',
+  endpointHost: 'localhost',
+  endpointPort: '8000',
+};
+
+export default class ThothPlugin extends Plugin {
+  settings: ThothPluginSettings;
+  process: ChildProcessWithoutNullStreams | null = null;
+
+  async onload() {
+    await this.loadSettings();
+    this.addSettingTab(new ThothSettingTab(this.app, this));
+
+    this.addCommand({
+      id: 'start-thoth-agent',
+      name: 'Start Agent',
+      callback: () => this.startAgent(),
+    });
+
+    this.addCommand({
+      id: 'open-thoth-chat',
+      name: 'Open Chat',
+      callback: () => this.openChat(),
+    });
+  }
+
+  onunload() {
+    if (this.process) {
+      this.process.kill();
+    }
+  }
+
+  async loadSettings() {
+    this.settings = Object.assign({}, DEFAULT_SETTINGS, await this.loadData());
+  }
+
+  async saveSettings() {
+    await this.saveData(this.settings);
+    const envPath = path.join(this.app.vault.adapter.getBasePath(), '.env');
+    const lines = [
+      `API_MISTRAL_KEY=${this.settings.mistralKey}`,
+      `API_OPENROUTER_KEY=${this.settings.openrouterKey}`,
+      `ENDPOINT_HOST=${this.settings.endpointHost}`,
+      `ENDPOINT_PORT=${this.settings.endpointPort}`,
+    ];
+    fs.writeFileSync(envPath, lines.join('\n'), 'utf8');
+  }
+
+  startAgent() {
+    if (this.process) {
+      new Notice('Agent already running');
+      return;
+    }
+
+    const cmd = 'thoth';
+    const args = ['agent'];
+    this.process = spawn(cmd, args, {
+      cwd: this.app.vault.adapter.getBasePath(),
+    });
+
+    this.process.stdout.on('data', (data) => {
+      console.log('thoth:', data.toString());
+    });
+    this.process.stderr.on('data', (data) => {
+      console.error('thoth:', data.toString());
+    });
+    this.process.on('close', () => {
+      this.process = null;
+    });
+
+    new Notice('Thoth agent started');
+  }
+
+  openChat() {
+    new ChatModal(this.app, this).open();
+  }
+}
+
+class ThothSettingTab extends PluginSettingTab {
+  plugin: ThothPlugin;
+
+  constructor(app: App, plugin: ThothPlugin) {
+    super(app, plugin);
+    this.plugin = plugin;
+  }
+
+  display(): void {
+    const { containerEl } = this;
+    containerEl.empty();
+
+    new Setting(containerEl)
+      .setName('Mistral API Key')
+      .addText((text) =>
+        text
+          .setPlaceholder('Enter Mistral API key')
+          .setValue(this.plugin.settings.mistralKey)
+          .onChange(async (value) => {
+            this.plugin.settings.mistralKey = value;
+            await this.plugin.saveSettings();
+          })
+      );
+
+    new Setting(containerEl)
+      .setName('OpenRouter API Key')
+      .addText((text) =>
+        text
+          .setPlaceholder('Enter OpenRouter API key')
+          .setValue(this.plugin.settings.openrouterKey)
+          .onChange(async (value) => {
+            this.plugin.settings.openrouterKey = value;
+            await this.plugin.saveSettings();
+          })
+      );
+
+    new Setting(containerEl)
+      .setName('Endpoint Host')
+      .addText((text) =>
+        text
+          .setPlaceholder('localhost')
+          .setValue(this.plugin.settings.endpointHost)
+          .onChange(async (value) => {
+            this.plugin.settings.endpointHost = value;
+            await this.plugin.saveSettings();
+          })
+      );
+
+    new Setting(containerEl)
+      .setName('Endpoint Port')
+      .addText((text) =>
+        text
+          .setPlaceholder('8000')
+          .setValue(this.plugin.settings.endpointPort)
+          .onChange(async (value) => {
+            this.plugin.settings.endpointPort = value;
+            await this.plugin.saveSettings();
+          })
+      );
+
+    new Setting(containerEl)
+      .setName('Start Agent')
+      .addButton((btn) =>
+        btn.setButtonText('Start').onClick(() => {
+          this.plugin.startAgent();
+        })
+      );
+  }
+}
+
+class ChatModal extends Modal {
+  plugin: ThothPlugin;
+  inputEl!: HTMLInputElement;
+  outputEl!: HTMLDivElement;
+
+  constructor(app: App, plugin: ThothPlugin) {
+    super(app);
+    this.plugin = plugin;
+  }
+
+  onOpen() {
+    const { contentEl } = this;
+    this.outputEl = contentEl.createDiv({ cls: 'thoth-output' });
+    const inputWrapper = contentEl.createDiv();
+    this.inputEl = inputWrapper.createEl('input', { type: 'text' });
+    inputWrapper.createEl('button', { text: 'Send' }).onclick = () => this.sendInput();
+  }
+
+  sendInput() {
+    if (!this.plugin.process) {
+      new Notice('Agent not running');
+      return;
+    }
+    const text = this.inputEl.value;
+    this.plugin.process.stdin.write(text + '\n');
+    this.inputEl.value = '';
+  }
+
+  onClose() {
+    const { contentEl } = this;
+    contentEl.empty();
+  }
+}

--- a/obsidian-plugin/thoth-obsidian/manifest.json
+++ b/obsidian-plugin/thoth-obsidian/manifest.json
@@ -1,0 +1,6 @@
+{
+  "id": "thoth-obsidian",
+  "name": "Thoth Research Assistant",
+  "version": "0.1.0",
+  "main": "main.js"
+}

--- a/obsidian-plugin/thoth-obsidian/package.json
+++ b/obsidian-plugin/thoth-obsidian/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "thoth-obsidian",
+  "version": "0.1.0",
+  "main": "main.js",
+  "scripts": {
+    "build": "tsc"
+  },
+  "devDependencies": {
+    "@types/node": "^18.17.0",
+    "typescript": "^5.3.3",
+    "@types/obsidian": "^0.15.0"
+  }
+}

--- a/obsidian-plugin/thoth-obsidian/tsconfig.json
+++ b/obsidian-plugin/thoth-obsidian/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ES2020",
+    "outDir": "./",
+    "strict": true,
+    "esModuleInterop": true,
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "skipLibCheck": true
+  },
+  "include": ["./main.ts"],
+  "exclude": []
+}


### PR DESCRIPTION
## Summary
- create `thoth-obsidian` plugin skeleton for Obsidian
- add manifest and build files
- implement `main.ts` plugin entry with settings tab and chat modal
- document how to build and install the plugin

## Testing
- `./run_tests.sh unit` *(fails: Required test coverage of 28% not reached)*

------
https://chatgpt.com/codex/tasks/task_e_683f786d00cc83248e94f8a2ca85b0ab