### PR TITLE
Add local PDF conversion fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Thoth is a production-ready AI-powered research assistant that automates the col
 ## ✨ Key Features
 
 ### 📚 **Automated Paper Processing**
-- **PDF OCR Conversion**: Converts academic PDFs to markdown using Mistral's OCR
+- **PDF Conversion**: Converts PDFs to markdown via Mistral OCR or a local fallback
 - **Content Analysis**: Extracts key findings, methodology, results using LLMs
 - **Citation Extraction**: Identifies and processes all references with metadata enrichment
 - **Note Generation**: Creates structured Obsidian-compatible notes automatically
@@ -32,7 +32,7 @@ Thoth is a production-ready AI-powered research assistant that automates the col
 
 - Python 3.10+
 - API Keys:
-  - **Mistral API**: For PDF OCR conversion
+  - **Mistral API** (optional): For remote OCR conversion
   - **OpenRouter API**: For LLM analysis and agent
   - **OpenCitations** (optional): For citation metadata
   - **Semantic Scholar** (optional): For citation enrichment
@@ -316,7 +316,7 @@ This project is licensed under the MIT License - see the LICENSE file for detail
 ## 🙏 Acknowledgments
 
 - Built with [LangChain](https://langchain.com/) and [LangGraph](https://github.com/langchain-ai/langgraph)
-- OCR powered by [Mistral AI](https://mistral.ai/)
+- OCR optionally powered by [Mistral AI](https://mistral.ai/)
 - LLMs via [OpenRouter](https://openrouter.ai/)
 - Citation data from [OpenCitations](https://opencitations.net/) and [Semantic Scholar](https://semanticscholar.org/)
 

--- a/docs/OBSIDIAN_PLUGIN_README.md
+++ b/docs/OBSIDIAN_PLUGIN_README.md
@@ -7,14 +7,14 @@ An intelligent research assistant plugin that brings AI-powered research capabil
 Before you begin, make sure you have:
 
 - [ ] **Thoth installed**: Test with `uv run python -m thoth --help` in terminal
-- [ ] **API Keys**: Get [Mistral API](https://console.mistral.ai) and [OpenRouter API](https://openrouter.ai) keys
+- [ ] **API Keys**: Get [OpenRouter API](https://openrouter.ai) key (Mistral key optional)
 - [ ] **Plugin installed**: Enable in Obsidian Settings → Community Plugins
 
 ### **Essential Setup (5 minutes)**
 
 1. **Configure API Keys** (Settings → Community Plugins → Thoth Research Assistant):
-   - Enter your Mistral API Key
    - Enter your OpenRouter API Key
+   - Enter your Mistral API Key if available
 
 2. **Set Directories**:
    - **Workspace Directory**: `/home/nick/python/project-thoth` (where you cloned the repo)
@@ -102,7 +102,7 @@ Run Thoth in Docker and connect from any Obsidian:
 
 1. Open Obsidian Settings → Community Plugins → Thoth Research Assistant
 2. Configure your API keys:
-   - **Mistral API Key**: Your API key for Mistral AI services
+   - **Mistral API Key** (optional): Your API key for Mistral AI services
    - **OpenRouter API Key**: Your API key for OpenRouter (multiple model access)
 3. Set connection details:
    - **Endpoint Host**: Usually `localhost` for local installations
@@ -232,7 +232,7 @@ This project is licensed under the MIT License - see the [LICENSE](LICENSE) file
 ## 🙏 Acknowledgments
 
 - Built for the [Obsidian](https://obsidian.md) knowledge management platform
-- Powered by [Mistral AI](https://mistral.ai) and [OpenRouter](https://openrouter.ai)
+- Powered by [OpenRouter](https://openrouter.ai) with optional OCR from [Mistral AI](https://mistral.ai)
 - Inspired by the need for seamless research integration
 
 ## 🔮 Roadmap

--- a/docs/OBSIDIAN_TROUBLESHOOTING.md
+++ b/docs/OBSIDIAN_TROUBLESHOOTING.md
@@ -44,7 +44,7 @@ The latest version includes comprehensive remote management capabilities to solv
 - **On Connect**: When connecting to remote server
 
 ### **What Gets Synced**
-- **API Keys**: Mistral, OpenRouter keys
+- **API Keys**: OpenRouter (Mistral optional) keys
 - **Directories**: Workspace and Obsidian paths
 - **Server Settings**: Host, port configuration
 - **Plugin Preferences**: Auto-start, status bar settings
@@ -178,7 +178,7 @@ tail -f logs/thoth.log | grep "obsidian.py"
 ### **Settings Checklist**
 
 #### **Required Settings**
-- [ ] **Mistral API Key**: Must be valid
+- [ ] **Mistral API Key** (optional): Provide if using remote OCR
 - [ ] **OpenRouter API Key**: Must be valid
 - [ ] **Workspace Directory**: Must exist and contain `pyproject.toml`
 - [ ] **Remote URL**: Must be reachable (if using remote mode)

--- a/docs/OBSIDIAN_USAGE_GUIDE.md
+++ b/docs/OBSIDIAN_USAGE_GUIDE.md
@@ -30,8 +30,8 @@ Before using the plugin, ensure you have:
    ```
 
 2. **API Keys Configured**:
-   - At minimum: **Mistral API Key** AND **OpenRouter API Key**
-   - Both are required for the agent to function
+   - At minimum: **OpenRouter API Key**
+   - **Mistral API Key** is optional for remote OCR
 
 3. **Directory Structure**:
    - Set correct workspace directory (where project-thoth is located)
@@ -40,7 +40,7 @@ Before using the plugin, ensure you have:
 ### **2. First Time Setup**
 
 1. **Configure Plugin**: Go to Settings → Community Plugins → Thoth Research Assistant
-2. **Set API Keys**: Enter your Mistral and OpenRouter API keys
+2. **Set API Keys**: Enter your OpenRouter API key (Mistral key optional)
 3. **Set Directories**:
    - **Workspace Directory**: `/home/nick/python/project-thoth`
    - **Obsidian Directory**: `/path/to/your/obsidian/vault/thoth`
@@ -51,8 +51,8 @@ Before using the plugin, ensure you have:
 Go to **Settings → Community plugins → Thoth Research Assistant**:
 
 #### **🔑 API Keys (Required)**
-- **Mistral API Key**: For PDF processing and OCR
-- **OpenRouter API Key**: For AI research capabilities
+ - **Mistral API Key** (optional): For remote OCR
+ - **OpenRouter API Key**: For AI research capabilities
 
 #### **📁 Directory Settings (Critical)**
 - **Workspace Directory**: `/home/nick/python/project-thoth` (where you cloned the repo)
@@ -195,7 +195,7 @@ uv run python -m thoth --help
 
 #### **Check 2: API Keys**
 - Go to plugin settings
-- Verify Mistral API key is set
+- Verify Mistral API key is set (optional)
 - Verify OpenRouter API key is set
 - Test keys at their respective websites
 
@@ -222,7 +222,7 @@ curl -LsSf https://astral.sh/uv/install.sh | sh
 
 #### **"API key error"**
 **Solution**: Check API keys in plugin settings
-- Visit [console.mistral.ai](https://console.mistral.ai) for Mistral key
+- Visit [console.mistral.ai](https://console.mistral.ai) for a Mistral key (optional)
 - Visit [openrouter.ai](https://openrouter.ai) for OpenRouter key
 
 #### **"Address already in use"**

--- a/docs/QUICK_SETUP.md
+++ b/docs/QUICK_SETUP.md
@@ -13,8 +13,8 @@ cp -r dist/* /path/to/your/vault/.obsidian/plugins/thoth-research-assistant/
 2. **Enable Remote Mode**: Toggle ON
 3. **Set Remote URL**: `http://localhost:8000`
 4. **Add API Keys**:
-   - Mistral API Key: `your_mistral_key`
    - OpenRouter API Key: `your_openrouter_key`
+   - Mistral API Key (optional): `your_mistral_key`
 5. **Set Directories**:
    - Workspace Directory: `/home/nick/python/project-thoth`
    - Obsidian Directory: `/path/to/your/vault/thoth`

--- a/src/thoth/utilities/config.py
+++ b/src/thoth/utilities/config.py
@@ -20,7 +20,9 @@ class APIKeys(BaseSettings):
         case_sensitive=False,  # Make case-insensitive to handle env vars
         extra='allow',
     )
-    mistral_key: str = Field(..., description='Mistral API key for OCR')
+    mistral_key: str | None = Field(
+        None, description='Mistral API key for OCR (optional)'
+    )
     openrouter_key: str = Field(..., description='OpenRouter API key for LLM')
     opencitations_key: str = Field(..., description='OpenCitations API key')
     google_api_key: str | None = Field(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -142,7 +142,14 @@ def sample_pdf_path(temp_workspace):
         Path: Path to the sample PDF file.
     """
     pdf_path = temp_workspace / 'pdf' / 'sample.pdf'
-    pdf_path.write_bytes(b'Sample PDF content for testing')
+
+    from pypdf import PdfWriter
+
+    writer = PdfWriter()
+    writer.add_blank_page(width=72, height=72)
+    with open(pdf_path, 'wb') as f:
+        writer.write(f)
+
     return pdf_path
 
 

--- a/tests/test_services/test_processing_service.py
+++ b/tests/test_services/test_processing_service.py
@@ -199,3 +199,16 @@ This is the content of the paper.
 
             assert pdf_out.exists()
             assert markdown_out == no_images_path
+
+    def test_local_conversion_without_mistral_key(
+        self, processing_service, sample_pdf_path, temp_workspace
+    ):
+        """Test fallback conversion when no Mistral key is set."""
+        processing_service.config.api_keys.mistral_key = None
+
+        md_path, no_img_path = processing_service.ocr_convert(
+            sample_pdf_path, output_dir=temp_workspace
+        )
+
+        assert md_path.exists()
+        assert no_img_path.exists()


### PR DESCRIPTION
## Summary
- add optional mistral key in config
- implement fallback `ProcessingService._local_pdf_to_markdown`
- use local conversion when no Mistral key available
- adjust docs to mark Mistral API as optional
- update tests for new functionality

## Testing
- `pre-commit run --files README.md docs/OBSIDIAN_PLUGIN_README.md docs/OBSIDIAN_TROUBLESHOOTING.md docs/OBSIDIAN_USAGE_GUIDE.md docs/QUICK_SETUP.md src/thoth/services/processing_service.py src/thoth/utilities/config.py tests/conftest.py tests/test_services/test_processing_service.py`
- `./run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_684465aa46d88324ac8977bd762c0a5a