### PR TITLE
Add Serper web search support

### DIFF
--- a/docs/OBSIDIAN_PLUGIN_README.md
+++ b/docs/OBSIDIAN_PLUGIN_README.md
@@ -15,6 +15,8 @@ Before you begin, make sure you have:
 1. **Configure API Keys** (Settings → Community Plugins → Thoth Research Assistant):
    - Enter your OpenRouter API Key
    - Enter your Mistral API Key if available
+   - *(Optional)* Enter your Serper API Key for web search
+   - Choose enabled Web Search Providers (Serper, DuckDuckGo, Scrape)
 
 2. **Set Directories**:
    - **Workspace Directory**: `/home/nick/python/project-thoth` (where you cloned the repo)
@@ -116,6 +118,8 @@ Run Thoth in Docker and connect from any Obsidian:
 To get your API keys:
 - **Mistral AI**: Visit [console.mistral.ai](https://console.mistral.ai)
 - **OpenRouter**: Visit [openrouter.ai](https://openrouter.ai)
+- **Serper**: Visit [serper.dev](https://serper.dev)
+- **DuckDuckGo Search**: Uses built-in library, no key required
 
 ## 🎯 Usage
 

--- a/docs/QUICK_SETUP.md
+++ b/docs/QUICK_SETUP.md
@@ -15,6 +15,8 @@ cp -r dist/* /path/to/your/vault/.obsidian/plugins/thoth-research-assistant/
 4. **Add API Keys**:
    - OpenRouter API Key: `your_openrouter_key`
    - Mistral API Key (optional): `your_mistral_key`
+   - Serper API Key (optional): `your_serper_key`
+   - Web Search Providers: `serper,duckduckgo`
 5. **Set Directories**:
    - Workspace Directory: `/home/nick/python/project-thoth`
    - Obsidian Directory: `/path/to/your/vault/thoth`

--- a/obsidian-plugin/thoth-obsidian/main.js
+++ b/obsidian-plugin/thoth-obsidian/main.js
@@ -19,6 +19,8 @@ const DEFAULT_SETTINGS = {
     googleApiKey: '',
     googleSearchEngineId: '',
     semanticscholarApiKey: '',
+    webSearchKey: '',
+    webSearchProviders: 'serper',
     // Default Model Settings
     modelTemperature: 0.9,
     modelMaxTokens: 50000,
@@ -208,6 +210,8 @@ class ThothPlugin extends obsidian_1.Plugin {
                     `API_GOOGLE_API_KEY=${this.settings.googleApiKey}`,
                     `API_GOOGLE_SEARCH_ENGINE_ID=${this.settings.googleSearchEngineId}`,
                     `API_SEMANTICSCHOLAR_API_KEY=${this.settings.semanticscholarApiKey}`,
+                    `API_WEB_SEARCH_KEY=${this.settings.webSearchKey}`,
+                    `API_WEB_SEARCH_PROVIDERS=${this.settings.webSearchProviders}`,
                     '',
                     '# ----------------------------------------------------------------------------------',
                     '# --- 2. Default Model Settings ---',
@@ -476,7 +480,7 @@ class ThothPlugin extends obsidian_1.Plugin {
                 // Create environment with all necessary variables
                 const envVars = Object.assign(Object.assign({}, process.env), {
                     // API Keys
-                    API_MISTRAL_KEY: this.settings.mistralKey, API_OPENROUTER_KEY: this.settings.openrouterKey, API_OPENCITATIONS_KEY: this.settings.opencitationsKey, API_GOOGLE_API_KEY: this.settings.googleApiKey, API_GOOGLE_SEARCH_ENGINE_ID: this.settings.googleSearchEngineId, API_SEMANTICSCHOLAR_API_KEY: this.settings.semanticscholarApiKey,
+                    API_MISTRAL_KEY: this.settings.mistralKey, API_OPENROUTER_KEY: this.settings.openrouterKey, API_OPENCITATIONS_KEY: this.settings.opencitationsKey, API_GOOGLE_API_KEY: this.settings.googleApiKey, API_GOOGLE_SEARCH_ENGINE_ID: this.settings.googleSearchEngineId, API_SEMANTICSCHOLAR_API_KEY: this.settings.semanticscholarApiKey, API_WEB_SEARCH_KEY: this.settings.webSearchKey, API_WEB_SEARCH_PROVIDERS: this.settings.webSearchProviders,
                     // Endpoint Configuration
                     ENDPOINT_HOST: this.settings.endpointHost, ENDPOINT_PORT: this.settings.endpointPort, ENDPOINT_BASE_URL: this.settings.endpointBaseUrl,
                     // Directory Configuration
@@ -803,6 +807,26 @@ class ThothSettingTab extends obsidian_1.PluginSettingTab {
             .setValue(this.plugin.settings.semanticscholarApiKey)
             .onChange((value) => __awaiter(this, void 0, void 0, function* () {
             this.plugin.settings.semanticscholarApiKey = value;
+            yield this.plugin.saveSettings();
+        })));
+        new obsidian_1.Setting(containerEl)
+            .setName('Serper API Key')
+            .setDesc('API key for web search via Serper.dev')
+            .addText((text) => text
+            .setPlaceholder('Enter Serper API key')
+            .setValue(this.plugin.settings.webSearchKey)
+            .onChange((value) => __awaiter(this, void 0, void 0, function* () {
+            this.plugin.settings.webSearchKey = value;
+            yield this.plugin.saveSettings();
+        })));
+        new obsidian_1.Setting(containerEl)
+            .setName('Web Search Providers')
+            .setDesc('Comma-separated providers')
+            .addText((text) => text
+            .setPlaceholder('serper,duckduckgo')
+            .setValue(this.plugin.settings.webSearchProviders)
+            .onChange((value) => __awaiter(this, void 0, void 0, function* () {
+            this.plugin.settings.webSearchProviders = value;
             yield this.plugin.saveSettings();
         })));
         // Model Configuration Section

--- a/obsidian-plugin/thoth-obsidian/main.ts
+++ b/obsidian-plugin/thoth-obsidian/main.ts
@@ -17,6 +17,8 @@ interface ThothSettings {
   googleApiKey: string;
   googleSearchEngineId: string;
   semanticScholarKey: string;
+  webSearchKey: string;
+  webSearchProviders: string;
 
   // === DIRECTORY CONFIGURATION ===
   workspaceDirectory: string;
@@ -105,6 +107,8 @@ const DEFAULT_SETTINGS: ThothSettings = {
   googleApiKey: '',
   googleSearchEngineId: '',
   semanticScholarKey: '',
+  webSearchKey: '',
+  webSearchProviders: 'serper',
 
   // === DIRECTORY CONFIGURATION ===
   workspaceDirectory: '',
@@ -612,6 +616,8 @@ export default class ThothPlugin extends Plugin {
       API_GOOGLE_API_KEY: this.settings.googleApiKey,
       API_GOOGLE_SEARCH_ENGINE_ID: this.settings.googleSearchEngineId,
       API_SEMANTIC_SCHOLAR_KEY: this.settings.semanticScholarKey,
+      API_WEB_SEARCH_KEY: this.settings.webSearchKey,
+      API_WEB_SEARCH_PROVIDERS: this.settings.webSearchProviders,
 
       // Directories
       WORKSPACE_DIR: this.settings.workspaceDirectory,
@@ -692,6 +698,8 @@ export default class ThothPlugin extends Plugin {
         `API_GOOGLE_API_KEY=${this.settings.googleApiKey}`,
         `API_GOOGLE_SEARCH_ENGINE_ID=${this.settings.googleSearchEngineId}`,
         `API_SEMANTIC_SCHOLAR_KEY=${this.settings.semanticScholarKey}`,
+        `API_WEB_SEARCH_KEY=${this.settings.webSearchKey}`,
+        `API_WEB_SEARCH_PROVIDERS=${this.settings.webSearchProviders}`,
         '',
         '# ----------------------------------------------------------------------------------',
         '# --- 2. Directory Configuration ---',
@@ -1134,6 +1142,33 @@ class ThothSettingTab extends PluginSettingTab {
           .setValue(this.plugin.settings.semanticScholarKey)
           .onChange(async (value) => {
             this.plugin.settings.semanticScholarKey = value;
+            await this.plugin.saveSettings();
+          });
+      });
+
+    new Setting(optionalApiSection)
+      .setName('Serper API Key')
+      .setDesc('For general web search integration')
+      .addText((text) => {
+        text.inputEl.type = 'password';
+        text
+          .setPlaceholder('Enter your Serper API key')
+          .setValue(this.plugin.settings.webSearchKey)
+          .onChange(async (value) => {
+            this.plugin.settings.webSearchKey = value;
+            await this.plugin.saveSettings();
+          });
+      });
+
+    new Setting(optionalApiSection)
+      .setName('Web Search Providers')
+      .setDesc('Comma-separated providers e.g. "serper,duckduckgo"')
+      .addText((text) => {
+        text
+          .setPlaceholder('serper,duckduckgo')
+          .setValue(this.plugin.settings.webSearchProviders)
+          .onChange(async (value) => {
+            this.plugin.settings.webSearchProviders = value;
             await this.plugin.saveSettings();
           });
       });

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,7 @@ dependencies = [
     "sqlalchemy>=2.0.39",
     "deprecated>=1.2.18",
     "httpx>=0.27.0",
+    "duckduckgo-search>=5.2",
     "jsonpatch>=1.33",
     "roman-numerals-py>=3.1.0",
     "feedparser>=6.0.11",

--- a/src/thoth/ingestion/agent_adapter.py
+++ b/src/thoth/ingestion/agent_adapter.py
@@ -14,6 +14,7 @@ from thoth.utilities.models import (
     DiscoverySource,
     QueryEvaluationResponse,
     ResearchQuery,
+    SearchResult,
 )
 
 
@@ -131,6 +132,14 @@ class AgentAdapter:
     def ask_knowledge(self, question: str, k: int = 4) -> dict[str, Any]:
         """Ask a question about the knowledge base."""
         return self.services.rag.ask_question(question, k)
+
+    def web_search(
+        self, query: str, num_results: int = 5, provider: str | None = None
+    ) -> list[SearchResult]:
+        """Perform a general web search."""
+        return self.services.web_search.search(
+            query, num_results, provider=provider
+        )
 
     def index_knowledge_file(self, file_path: Path) -> bool:
         """Index a file to the knowledge base."""

--- a/src/thoth/ingestion/agent_v2/core/agent.py
+++ b/src/thoth/ingestion/agent_v2/core/agent.py
@@ -43,6 +43,7 @@ from thoth.ingestion.agent_v2.tools.rag_tools import (
     IndexKnowledgeBaseTool,
     SearchKnowledgeTool,
 )
+from thoth.ingestion.agent_v2.tools.web_tools import WebSearchTool
 
 
 class ResearchAssistant:
@@ -118,6 +119,7 @@ class ResearchAssistant:
         self.tool_registry.register('index_knowledge', IndexKnowledgeBaseTool)
         self.tool_registry.register('explain_connections', ExplainConnectionsTool)
         self.tool_registry.register('rag_stats', GetRAGStatsTool)
+        self.tool_registry.register('web_search', WebSearchTool)
 
         # Analysis tools
         self.tool_registry.register('evaluate_article', EvaluateArticleTool)

--- a/src/thoth/ingestion/agent_v2/tools/web_tools.py
+++ b/src/thoth/ingestion/agent_v2/tools/web_tools.py
@@ -1,0 +1,41 @@
+"""Tools for general web search."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+
+from thoth.ingestion.agent_v2.tools.base_tool import BaseThothTool
+
+
+class WebSearchInput(BaseModel):
+    """Input schema for web search."""
+
+    query: str = Field(description="Search query")
+    num_results: int = Field(default=5, description="Number of results to return")
+    provider: str | None = Field(
+        default=None,
+        description="Preferred search provider (serper, duckduckgo, scrape)",
+    )
+
+
+class WebSearchTool(BaseThothTool):
+    """Tool that performs a general web search."""
+
+    name: str = "web_search"
+    description: str = "Search the web using the configured search API"
+    args_schema: type[BaseModel] = WebSearchInput
+
+    def _run(
+        self, query: str, num_results: int = 5, provider: str | None = None
+    ) -> str:
+        try:
+            results = self.adapter.web_search(query, num_results, provider)
+            if not results:
+                return "❌ No search results found or API key not configured."
+
+            output = f"🔎 **Web Search Results for:** \"{query}\"\n\n"
+            for r in results:
+                output += f"**{r.position}. {r.title}**\n{r.link}\n{r.snippet}\n\n"
+            return output.strip()
+        except Exception as e:
+            return self.handle_error(e, "web search")

--- a/src/thoth/pipeline.py
+++ b/src/thoth/pipeline.py
@@ -17,7 +17,7 @@ from thoth.ingestion.filter import Filter
 from thoth.monitor.tracker import CitationTracker
 from thoth.services.service_manager import ServiceManager
 from thoth.utilities.config import get_config
-from thoth.utilities.models import Citation
+from thoth.utilities.models import Citation, SearchResult
 
 
 class PipelineError(Exception):
@@ -492,6 +492,19 @@ class ThothPipeline:
         except Exception as e:
             logger.error(f'Failed to answer question: {e}')
             raise PipelineError(f'Failed to answer question: {e}') from e
+
+    def web_search(
+        self, query: str, num_results: int = 5, provider: str | None = None
+    ) -> list[SearchResult]:
+        """Perform a general web search."""
+        try:
+            logger.info(f'Performing web search for: {query}')
+            return self.services.web_search.search(
+                query, num_results, provider=provider
+            )
+        except Exception as e:
+            logger.error(f'Web search failed: {e}')
+            raise PipelineError(f'Web search failed: {e}') from e
 
     def clear_rag_index(self) -> None:
         """

--- a/src/thoth/services/__init__.py
+++ b/src/thoth/services/__init__.py
@@ -14,6 +14,7 @@ from thoth.services.note_service import NoteService
 from thoth.services.processing_service import ProcessingService
 from thoth.services.query_service import QueryService
 from thoth.services.rag_service import RAGService
+from thoth.services.web_search_service import WebSearchService
 from thoth.services.service_manager import ServiceManager
 from thoth.services.tag_service import TagService
 
@@ -27,6 +28,7 @@ __all__ = [
     'ProcessingService',
     'QueryService',
     'RAGService',
+    'WebSearchService',
     'ServiceManager',
     'TagService',
 ]

--- a/src/thoth/services/service_manager.py
+++ b/src/thoth/services/service_manager.py
@@ -16,6 +16,7 @@ from thoth.services.note_service import NoteService
 from thoth.services.processing_service import ProcessingService
 from thoth.services.query_service import QueryService
 from thoth.services.rag_service import RAGService
+from thoth.services.web_search_service import WebSearchService
 from thoth.services.tag_service import TagService
 from thoth.utilities.config import ThothConfig, get_config
 
@@ -63,6 +64,8 @@ class ServiceManager:
         )
 
         self._services['rag'] = RAGService(config=self.config)
+
+        self._services['web_search'] = WebSearchService(config=self.config)
 
         # Initialize services that need dependencies
         self._services['citation'] = CitationService(config=self.config)
@@ -115,6 +118,12 @@ class ServiceManager:
         """Get the RAG service."""
         self._ensure_initialized()
         return self._services['rag']
+
+    @property
+    def web_search(self) -> WebSearchService:
+        """Get the web search service."""
+        self._ensure_initialized()
+        return self._services['web_search']
 
     @property
     def citation(self) -> CitationService:

--- a/src/thoth/services/web_search_service.py
+++ b/src/thoth/services/web_search_service.py
@@ -1,0 +1,79 @@
+"""Service for performing general web searches."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from thoth.services.base import BaseService, ServiceError
+from thoth.utilities.models import SearchResult
+from thoth.utilities.web_search import (
+    DuckDuckGoClient,
+    ScrapeSearchClient,
+    SerperClient,
+)
+
+
+class WebSearchService(BaseService):
+    """Service wrapping search clients for agent use."""
+
+    def __init__(self, config=None):
+        super().__init__(config)
+        self._clients: dict[str, Any] = {}
+
+    def _get_client(self, provider: str):
+        if provider in self._clients:
+            return self._clients[provider]
+
+        if provider == "serper":
+            api_key = self.config.api_keys.web_search_key
+            if not api_key:
+                raise ServiceError(
+                    "Web search API key is not configured. Set API_WEB_SEARCH_KEY."
+                )
+            client = SerperClient(api_key=api_key)
+        elif provider == "duckduckgo":
+            client = DuckDuckGoClient()
+        elif provider == "scrape":
+            client = ScrapeSearchClient()
+        else:
+            raise ServiceError(f"Unknown web search provider '{provider}'")
+
+        self._clients[provider] = client
+        return client
+
+    def initialize(self) -> None:
+        self.logger.info("Web search service initialized")
+
+    def search(
+        self, query: str, num_results: int = 5, provider: str | None = None
+    ) -> list[SearchResult]:
+        """Perform a web search."""
+        try:
+            self.validate_input(query=query)
+
+            providers = (
+                provider if provider else None
+            ) or self.config.api_keys.web_search_providers
+
+            if isinstance(providers, str):
+                providers = [p.strip() for p in providers.split(",") if p]
+
+            for prov in providers or ["serper"]:
+                try:
+                    client = self._get_client(prov)
+                except ServiceError as e:
+                    self.logger.warning(f"Provider {prov} unavailable: {e}")
+                    continue
+                try:
+                    results = client.search(query, num_results)
+                    if results:
+                        self.log_operation(
+                            "web_search", query=query, provider=prov, results=len(results)
+                        )
+                        return results
+                except Exception as e:
+                    self.logger.warning(f"Provider {prov} failed: {e}")
+
+            raise ServiceError("No available web search providers")
+        except Exception as e:
+            raise ServiceError(self.handle_error(e, "web searching")) from e

--- a/src/thoth/utilities/config.py
+++ b/src/thoth/utilities/config.py
@@ -34,6 +34,14 @@ class APIKeys(BaseSettings):
     semanticscholar_api_key: str | None = Field(
         None, description='Semantic Scholar API key'
     )
+    web_search_key: str | None = Field(
+        None, description='Serper.dev API key for general web search'
+    )
+    web_search_providers: list[str] = Field(
+        default_factory=lambda: ['serper'],
+        description='Comma-separated list of enabled web search providers '
+        '(serper, duckduckgo, scrape)',
+    )
 
 
 class ModelConfig(BaseSettings):

--- a/src/thoth/utilities/web_search.py
+++ b/src/thoth/utilities/web_search.py
@@ -1,0 +1,106 @@
+"""Web search clients for multiple providers."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+from loguru import logger
+
+from thoth.utilities.models import SearchResult
+
+
+class SerperClient:
+    """Client for performing web searches via the Serper.dev API."""
+
+    def __init__(self, api_key: str, base_url: str = "https://google.serper.dev"):
+        self.api_key = api_key
+        self.base_url = base_url.rstrip("/")
+        self.client = httpx.Client(timeout=10)
+
+    def search(self, query: str, num_results: int = 5) -> list[SearchResult]:
+        """Perform a web search and return results."""
+        try:
+            response = self.client.post(
+                f"{self.base_url}/search",
+                headers={"X-API-KEY": self.api_key},
+                json={"q": query, "num": num_results},
+            )
+            response.raise_for_status()
+            data = response.json()
+            results: list[SearchResult] = []
+            for i, item in enumerate(data.get("organic", [])[:num_results]):
+                results.append(
+                    SearchResult(
+                        title=item.get("title", ""),
+                        link=item.get("link", ""),
+                        snippet=item.get("snippet", ""),
+                        position=i + 1,
+                    )
+                )
+            return results
+        except Exception as e:
+            logger.error(f"Web search failed: {e}")
+            return []
+
+    def close(self) -> None:
+        self.client.close()
+
+
+class DuckDuckGoClient:
+    """Client for performing searches via DuckDuckGo."""
+
+    def search(self, query: str, num_results: int = 5) -> list[SearchResult]:
+        try:
+            from duckduckgo_search import DDGS
+
+            with DDGS() as ddgs:
+                results: list[SearchResult] = []
+                for i, r in enumerate(ddgs.text(query, max_results=num_results)):
+                    results.append(
+                        SearchResult(
+                            title=r.get("title", ""),
+                            link=r.get("href", ""),
+                            snippet=r.get("body", ""),
+                            position=i + 1,
+                        )
+                    )
+                return results
+        except Exception as e:
+            logger.error(f"DuckDuckGo search failed: {e}")
+            return []
+
+
+class ScrapeSearchClient:
+    """Fallback client that scrapes DuckDuckGo HTML results."""
+
+    def __init__(self, base_url: str = "https://duckduckgo.com/html/"):
+        self.base_url = base_url
+        self.client = httpx.Client(timeout=10)
+
+    def search(self, query: str, num_results: int = 5) -> list[SearchResult]:
+        try:
+            resp = self.client.get(self.base_url, params={"q": query})
+            resp.raise_for_status()
+            from bs4 import BeautifulSoup
+
+            soup = BeautifulSoup(resp.text, "html.parser")
+            results: list[SearchResult] = []
+            for i, res in enumerate(soup.select("div.result")[:num_results]):
+                link_el = res.select_one("a.result__a")
+                snippet_el = res.select_one("a.result__snippet")
+                results.append(
+                    SearchResult(
+                        title=link_el.text if link_el else "",
+                        link=link_el["href"] if link_el else "",
+                        snippet=snippet_el.text if snippet_el else "",
+                        position=i + 1,
+                    )
+                )
+            return results
+        except Exception as e:
+            logger.error(f"Scrape search failed: {e}")
+            return []
+
+    def close(self) -> None:
+        self.client.close()

--- a/tests/test_services/test_web_search_service.py
+++ b/tests/test_services/test_web_search_service.py
@@ -1,0 +1,40 @@
+import pytest
+
+from thoth.services.web_search_service import WebSearchService, ServiceError
+from thoth.utilities.config import ThothConfig
+from thoth.utilities.models import SearchResult
+
+
+def test_missing_api_key(monkeypatch):
+    config = ThothConfig()
+    config.api_keys.web_search_key = None
+    config.api_keys.web_search_providers = ["serper"]
+    service = WebSearchService(config=config)
+    with pytest.raises(ServiceError):
+        service.search("test")
+
+
+def test_fallback_to_duckduckgo(monkeypatch):
+    config = ThothConfig()
+    config.api_keys.web_search_key = None
+    config.api_keys.web_search_providers = ["serper", "duckduckgo"]
+
+    service = WebSearchService(config=config)
+
+    def mock_search(self, query, num_results):
+        return [SearchResult(title="t", link="u", snippet="s", position=1)]
+
+    monkeypatch.setattr(
+        "thoth.utilities.web_search.DuckDuckGoClient.search", mock_search
+    )
+
+    results = service.search("test")
+    assert len(results) == 1
+
+
+def test_invalid_provider():
+    config = ThothConfig()
+    config.api_keys.web_search_providers = ["bad"]
+    service = WebSearchService(config=config)
+    with pytest.raises(ServiceError):
+        service.search("test")


### PR DESCRIPTION
## Summary
- add multiple web search providers (Serper, DuckDuckGo, scrape)
- expose provider selection in config and Obsidian plugin
- expand `web_search` tool and pipeline
- document new provider options
- test web search service

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844738357a08324909fc4dbbe18089d