### PR TITLE
Integrate additional discovery sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Thoth is a production-ready AI-powered research assistant that automates the col
 - **Note Generation**: Creates structured Obsidian-compatible notes automatically
 
 ### 🔍 **Research Discovery & Filtering**
-- **Multi-Source Discovery**: Automated paper discovery from ArXiv, PubMed, and custom sources
+- **Multi-Source Discovery**: Automated paper discovery from ArXiv, PubMed, CrossRef, OpenAlex, bioRxiv, and custom sources
 - **Smart Filtering**: AI-powered evaluation of papers against research queries
 - **Scheduled Discovery**: Automated periodic searches for new relevant papers
 - **Web Scraping**: Support for custom journal scraping with Chrome extension

--- a/docs/DISCOVERY_SYSTEM_README.md
+++ b/docs/DISCOVERY_SYSTEM_README.md
@@ -5,7 +5,7 @@ The Thoth Discovery System is a comprehensive article discovery and scraping fra
 ## Features
 
 ### 🔍 **Multi-Source Discovery**
-- **API Sources**: ArXiv and PubMed integration with configurable search parameters
+- **API Sources**: ArXiv, PubMed, CrossRef, OpenAlex, and bioRxiv integration with configurable search parameters
 - **Web Scraping**: Flexible scraper that works with any website using CSS selectors
 - **Chrome Extension**: Point-and-click interface for configuring scrapers without coding
 
@@ -63,6 +63,88 @@ Create `arxiv_ml_config.json`:
     "days_of_week": [0, 1, 2, 3, 4]
   },
   "query_filters": ["machine_learning", "nlp_research"]
+}
+```
+
+#### CrossRef Source Example
+```bash
+# Create a CrossRef source for AI papers
+python -m thoth discovery create \
+  --name "crossref_ai" \
+  --type "api" \
+  --description "CrossRef AI papers" \
+  --config-file crossref_ai_config.json
+```
+
+Create `crossref_ai_config.json`:
+```json
+{
+  "api_config": {
+    "source": "crossref",
+    "keywords": ["artificial intelligence", "machine learning"],
+    "sort_by": "relevance",
+    "sort_order": "desc"
+  },
+  "schedule_config": {
+    "interval_minutes": 720,
+    "max_articles_per_run": 20,
+    "enabled": true
+  },
+  "query_filters": ["ai_research"]
+}
+```
+
+#### OpenAlex Source Example
+```bash
+# Create an OpenAlex source for AI papers
+python -m thoth discovery create \
+  --name "openalex_ai" \
+  --type "api" \
+  --description "OpenAlex AI papers" \
+  --config-file openalex_ai_config.json
+```
+
+Create `openalex_ai_config.json`:
+```json
+{
+  "api_config": {
+    "source": "openalex",
+    "keywords": ["artificial intelligence", "machine learning"],
+    "sort_by": "relevance"
+  },
+  "schedule_config": {
+    "interval_minutes": 720,
+    "max_articles_per_run": 20,
+    "enabled": true
+  },
+  "query_filters": ["ai_research"]
+}
+```
+
+#### bioRxiv Source Example
+```bash
+# Create a bioRxiv source for the past week
+python -m thoth discovery create \
+  --name "biorxiv_recent" \
+  --type "api" \
+  --description "Recent bioRxiv preprints" \
+  --config-file biorxiv_recent_config.json
+```
+
+Create `biorxiv_recent_config.json`:
+```json
+{
+  "api_config": {
+    "source": "biorxiv",
+    "start_date": "2024-01-01",
+    "end_date": "2024-01-07"
+  },
+  "schedule_config": {
+    "interval_minutes": 1440,
+    "max_articles_per_run": 50,
+    "enabled": true
+  },
+  "query_filters": []
 }
 ```
 
@@ -232,6 +314,45 @@ Define how to extract data from web pages using CSS selectors:
       "selector": "[data-doi]",
       "attribute": "data-doi"
     }
+  }
+}
+```
+
+### CrossRef Configuration Options
+
+```json
+{
+  "api_config": {
+    "source": "crossref",
+    "keywords": ["deep learning", "neural networks"],
+    "start_date": "2023-01-01",
+    "end_date": "2023-12-31",
+    "sort_by": "relevance",
+    "sort_order": "desc"
+  }
+}
+```
+
+### OpenAlex Configuration Options
+```json
+{
+  "api_config": {
+    "source": "openalex",
+    "keywords": ["deep learning"],
+    "start_date": "2023-01-01",
+    "end_date": "2023-12-31",
+    "sort_by": "relevance"
+  }
+}
+```
+
+### bioRxiv Configuration Options
+```json
+{
+  "api_config": {
+    "source": "biorxiv",
+    "start_date": "2024-01-01",
+    "end_date": "2024-01-07"
   }
 }
 ```

--- a/docs/MODERN_AGENT_README.md
+++ b/docs/MODERN_AGENT_README.md
@@ -59,6 +59,9 @@ agent_v2/
 - `list_discovery_sources` - Show all discovery sources
 - `create_arxiv_source` - Create an ArXiv source
 - `create_pubmed_source` - Create a PubMed source
+- `create_crossref_source` - Create a CrossRef source
+- `create_openalex_source` - Create an OpenAlex source
+- `create_biorxiv_source` - Create a bioRxiv source
 - `run_discovery` - Execute discovery for sources
 - `delete_discovery_source` - Remove a source
 

--- a/src/thoth/discovery/api_sources.py
+++ b/src/thoth/discovery/api_sources.py
@@ -573,3 +573,311 @@ class PubMedAPISource(BaseAPISource):
             time.sleep(sleep_time)
 
         self.last_request_time = time.time()
+
+
+class CrossRefAPISource(BaseAPISource):
+    """CrossRef API source for discovering scholarly works."""
+
+    def __init__(self, rate_limit_delay: float = 1.0):
+        """Initialize the CrossRef API source."""
+        self.base_url = "https://api.crossref.org/works"
+        self.rate_limit_delay = rate_limit_delay
+        self.last_request_time = 0.0
+
+    def search(
+        self, config: dict[str, Any], max_results: int = 50
+    ) -> list[ScrapedArticleMetadata]:
+        """Search CrossRef for works."""
+        try:
+            params = {
+                "rows": min(max_results, 100),
+                "sort": config.get("sort_by", "relevance"),
+                "order": config.get("sort_order", "desc"),
+            }
+
+            # Build query string
+            keywords = config.get("keywords", [])
+            if keywords:
+                params["query"] = " ".join(keywords)
+
+            # Date filters
+            start_date = config.get("start_date")
+            end_date = config.get("end_date")
+            filters = []
+            if start_date:
+                filters.append(f"from-pub-date:{start_date}")
+            if end_date:
+                filters.append(f"until-pub-date:{end_date}")
+            if filters:
+                params["filter"] = ",".join(filters)
+
+            logger.info(f"Searching CrossRef with params: {params}")
+
+            self._rate_limit()
+            response = requests.get(self.base_url, params=params, timeout=30)
+            response.raise_for_status()
+
+            data = response.json()
+            items = data.get("message", {}).get("items", [])
+            articles: list[ScrapedArticleMetadata] = []
+
+            for item in items:
+                try:
+                    article = self._parse_item(item)
+                    if article:
+                        articles.append(article)
+                except Exception as e:  # pragma: no cover - log and continue
+                    logger.error(f"Error parsing CrossRef item: {e}")
+
+            logger.info(f"Found {len(articles)} articles from CrossRef")
+            return articles
+
+        except Exception as e:
+            raise APISourceError(f"CrossRef search failed: {e}") from e
+
+    def _parse_item(self, item: dict[str, Any]) -> ScrapedArticleMetadata | None:
+        """Parse a single CrossRef item."""
+        title_list = item.get("title", [])
+        title = title_list[0] if title_list else None
+        if not title:
+            return None
+
+        authors = []
+        for a in item.get("author", []):
+            given = a.get("given")
+            family = a.get("family")
+            if given and family:
+                authors.append(f"{family}, {given}")
+            elif family:
+                authors.append(family)
+
+        abstract = item.get("abstract")
+
+        pub_date_parts = item.get("published-print") or item.get("published-online")
+        pub_date = None
+        if pub_date_parts and "date-parts" in pub_date_parts:
+            parts = pub_date_parts["date-parts"][0]
+            pub_date = "-".join(str(p) for p in parts)
+
+        journal_list = item.get("container-title", [])
+        journal = journal_list[0] if journal_list else None
+
+        doi = item.get("DOI")
+        url = item.get("URL")
+
+        pdf_url = None
+        for link in item.get("link", []):
+            if link.get("content-type") == "application/pdf":
+                pdf_url = link.get("URL")
+                break
+
+        keywords = item.get("subject", [])
+
+        return ScrapedArticleMetadata(
+            title=title,
+            authors=authors,
+            abstract=abstract,
+            publication_date=pub_date,
+            journal=journal,
+            doi=doi,
+            url=url,
+            pdf_url=pdf_url,
+            keywords=keywords,
+            source="crossref",
+            scrape_timestamp=datetime.now().isoformat(),
+            additional_metadata={"type": item.get("type")},
+        )
+
+    def _rate_limit(self) -> None:
+        current_time = time.time()
+        time_since_last = current_time - self.last_request_time
+        if time_since_last < self.rate_limit_delay:
+            time.sleep(self.rate_limit_delay - time_since_last)
+        self.last_request_time = time.time()
+
+
+class OpenAlexAPISource(BaseAPISource):
+    """OpenAlex API source for discovering scholarly works."""
+
+    def __init__(self, rate_limit_delay: float = 1.0):
+        self.base_url = "https://api.openalex.org/works"
+        self.rate_limit_delay = rate_limit_delay
+        self.last_request_time = 0.0
+
+    def search(
+        self, config: dict[str, Any], max_results: int = 50
+    ) -> list[ScrapedArticleMetadata]:
+        """Search OpenAlex for works."""
+        try:
+            params = {
+                "per-page": min(max_results, 200),
+                "sort": config.get("sort_by", "relevance"),
+            }
+
+            keywords = config.get("keywords", [])
+            if keywords:
+                params["search"] = " ".join(keywords)
+
+            filters = []
+            start_date = config.get("start_date")
+            end_date = config.get("end_date")
+            if start_date:
+                filters.append(f"from_publication_date:{start_date}")
+            if end_date:
+                filters.append(f"to_publication_date:{end_date}")
+            if filters:
+                params["filter"] = ",".join(filters)
+
+            logger.info(f"Searching OpenAlex with params: {params}")
+
+            self._rate_limit()
+            response = requests.get(self.base_url, params=params, timeout=30)
+            response.raise_for_status()
+
+            data = response.json()
+            items = data.get("results", [])
+            articles: list[ScrapedArticleMetadata] = []
+
+            for item in items:
+                try:
+                    article = self._parse_item(item)
+                    if article:
+                        articles.append(article)
+                except Exception as e:  # pragma: no cover - log and continue
+                    logger.error(f"Error parsing OpenAlex item: {e}")
+
+            logger.info(f"Found {len(articles)} articles from OpenAlex")
+            return articles
+
+        except Exception as e:
+            raise APISourceError(f"OpenAlex search failed: {e}") from e
+
+    def _parse_item(self, item: dict[str, Any]) -> ScrapedArticleMetadata | None:
+        title = item.get("title") or item.get("display_name")
+        if not title:
+            return None
+
+        authors = []
+        for a in item.get("authorships", []):
+            name = a.get("author", {}).get("display_name")
+            if name:
+                authors.append(name)
+
+        abstract = item.get("abstract")
+        pub_date = item.get("publication_date")
+
+        journal = None
+        container = item.get("host_venue") or {}
+        if container:
+            journal = container.get("display_name")
+
+        doi = item.get("doi")
+        url = container.get("url") if container else None
+        pdf_url = container.get("pdf_url") if container else None
+
+        keywords = [c.get("display_name") for c in item.get("concepts", []) if c.get("display_name")]
+
+        return ScrapedArticleMetadata(
+            title=title,
+            authors=authors,
+            abstract=abstract,
+            publication_date=pub_date,
+            journal=journal,
+            doi=doi,
+            url=url,
+            pdf_url=pdf_url,
+            keywords=keywords,
+            source="openalex",
+            scrape_timestamp=datetime.now().isoformat(),
+            additional_metadata={"id": item.get("id")},
+        )
+
+    def _rate_limit(self) -> None:
+        current_time = time.time()
+        time_since_last = current_time - self.last_request_time
+        if time_since_last < self.rate_limit_delay:
+            time.sleep(self.rate_limit_delay - time_since_last)
+        self.last_request_time = time.time()
+
+
+class BioRxivAPISource(BaseAPISource):
+    """bioRxiv API source for preprint articles."""
+
+    def __init__(self, rate_limit_delay: float = 1.0):
+        self.base_url = "https://api.biorxiv.org/details/biorxiv"
+        self.rate_limit_delay = rate_limit_delay
+        self.last_request_time = 0.0
+
+    def search(
+        self, config: dict[str, Any], max_results: int = 50
+    ) -> list[ScrapedArticleMetadata]:
+        """Search bioRxiv for preprints."""
+        try:
+            start_date = config.get("start_date") or datetime.now().strftime("%Y-%m-%d")
+            end_date = config.get("end_date") or start_date
+
+            url = f"{self.base_url}/{start_date}/{end_date}"
+            params = {"cursor": 0}
+
+            logger.info(f"Searching bioRxiv with URL: {url}")
+
+            self._rate_limit()
+            response = requests.get(url, params=params, timeout=30)
+            response.raise_for_status()
+
+            data = response.json()
+            items = data.get("collection", [])[:max_results]
+            articles: list[ScrapedArticleMetadata] = []
+
+            for item in items:
+                try:
+                    article = self._parse_item(item)
+                    if article:
+                        articles.append(article)
+                except Exception as e:  # pragma: no cover - log and continue
+                    logger.error(f"Error parsing bioRxiv item: {e}")
+
+            logger.info(f"Found {len(articles)} articles from bioRxiv")
+            return articles
+
+        except Exception as e:
+            raise APISourceError(f"bioRxiv search failed: {e}") from e
+
+    def _parse_item(self, item: dict[str, Any]) -> ScrapedArticleMetadata | None:
+        title = item.get("title")
+        if not title:
+            return None
+
+        authors = []
+        author_str = item.get("authors")
+        if author_str:
+            authors = [a.strip() for a in author_str.split(";") if a.strip()]
+
+        abstract = item.get("abstract")
+        pub_date = item.get("date")
+        journal = item.get("journal")
+        doi = item.get("doi")
+        url = item.get("biorxiv_url")
+        pdf_url = item.get("biorxiv_pdf")
+
+        return ScrapedArticleMetadata(
+            title=title,
+            authors=authors,
+            abstract=abstract,
+            publication_date=pub_date,
+            journal=journal,
+            doi=doi,
+            url=url,
+            pdf_url=pdf_url,
+            keywords=[],
+            source="biorxiv",
+            scrape_timestamp=datetime.now().isoformat(),
+            additional_metadata={"version": item.get("version")},
+        )
+
+    def _rate_limit(self) -> None:
+        current_time = time.time()
+        time_since_last = current_time - self.last_request_time
+        if time_since_last < self.rate_limit_delay:
+            time.sleep(self.rate_limit_delay - time_since_last)
+        self.last_request_time = time.time()

--- a/src/thoth/discovery/discovery_manager.py
+++ b/src/thoth/discovery/discovery_manager.py
@@ -14,7 +14,13 @@ from typing import Any
 
 from loguru import logger
 
-from thoth.discovery.api_sources import ArxivAPISource, PubMedAPISource
+from thoth.discovery.api_sources import (
+    ArxivAPISource,
+    PubMedAPISource,
+    CrossRefAPISource,
+    OpenAlexAPISource,
+    BioRxivAPISource,
+)
 from thoth.discovery.web_scraper import WebScraper
 from thoth.ingestion.filter import Filter
 from thoth.utilities.config import get_config
@@ -67,6 +73,9 @@ class DiscoveryManager:
         self.api_sources = {
             'arxiv': ArxivAPISource(),
             'pubmed': PubMedAPISource(),
+            'crossref': CrossRefAPISource(),
+            'openalex': OpenAlexAPISource(),
+            'biorxiv': BioRxivAPISource(),
         }
 
         # Initialize web scraper

--- a/src/thoth/ingestion/agent_v2/core/agent.py
+++ b/src/thoth/ingestion/agent_v2/core/agent.py
@@ -24,6 +24,9 @@ from thoth.ingestion.agent_v2.tools.base_tool import ToolRegistry
 from thoth.ingestion.agent_v2.tools.discovery_tools import (
     CreateArxivSourceTool,
     CreatePubmedSourceTool,
+    CreateCrossrefSourceTool,
+    CreateOpenalexSourceTool,
+    CreateBiorxivSourceTool,
     DeleteDiscoverySourceTool,
     ListDiscoverySourcesTool,
     RunDiscoveryTool,
@@ -103,6 +106,9 @@ class ResearchAssistant:
         self.tool_registry.register('list_discovery_sources', ListDiscoverySourcesTool)
         self.tool_registry.register('create_arxiv_source', CreateArxivSourceTool)
         self.tool_registry.register('create_pubmed_source', CreatePubmedSourceTool)
+        self.tool_registry.register('create_crossref_source', CreateCrossrefSourceTool)
+        self.tool_registry.register('create_openalex_source', CreateOpenalexSourceTool)
+        self.tool_registry.register('create_biorxiv_source', CreateBiorxivSourceTool)
         self.tool_registry.register('run_discovery', RunDiscoveryTool)
         self.tool_registry.register(
             'delete_discovery_source', DeleteDiscoverySourceTool

--- a/src/thoth/ingestion/agent_v2/tools/discovery_tools.py
+++ b/src/thoth/ingestion/agent_v2/tools/discovery_tools.py
@@ -184,6 +184,200 @@ class CreatePubmedSourceTool(BaseThothTool):
             return self.handle_error(e, 'creating PubMed source')
 
 
+class CreateCrossrefSourceInput(BaseModel):
+    """Input schema for creating a CrossRef source."""
+
+    name: str = Field(description='Unique name for the source')
+    keywords: list[str] = Field(description='Keywords to search for in CrossRef')
+    max_articles: int = Field(default=50, description='Maximum articles per run')
+    schedule_hours: int = Field(default=24, description='Run interval in hours')
+
+
+class CreateCrossrefSourceTool(BaseThothTool):
+    """Create a CrossRef discovery source."""
+
+    name: str = 'create_crossref_source'
+    description: str = (
+        'Create a CrossRef discovery source to automatically find papers. '
+        'Specify name and keywords.'
+    )
+    args_schema: type[BaseModel] = CreateCrossrefSourceInput
+
+    def _run(
+        self,
+        name: str,
+        keywords: list[str],
+        max_articles: int = 50,
+        schedule_hours: int = 24,
+    ) -> str:
+        """Create CrossRef source."""
+        try:
+            source_config = {
+                'name': name,
+                'source_type': 'api',
+                'description': f'CrossRef source for {", ".join(keywords)} research',
+                'is_active': True,
+                'api_config': {
+                    'source': 'crossref',
+                    'keywords': keywords,
+                    'sort_by': 'relevance',
+                    'sort_order': 'desc',
+                },
+                'schedule_config': {
+                    'interval_minutes': schedule_hours * 60,
+                    'max_articles_per_run': max_articles,
+                    'enabled': True,
+                },
+                'query_filters': [],
+            }
+
+            if self.adapter.create_discovery_source(source_config):
+                return (
+                    f'✅ **CrossRef Discovery Source Created Successfully!**\n\n'
+                    f'**Source Details:**\n'
+                    f'- Name: `{name}`\n'
+                    f'- Type: CrossRef API\n'
+                    f'- Keywords: {", ".join(keywords)}\n'
+                    f'- Schedule: Every {schedule_hours} hours, max {max_articles} articles\n\n'
+                    f'🚀 **Ready to use!**'
+                )
+            else:
+                return f"❌ Failed to create CrossRef source '{name}'"
+
+        except Exception as e:
+            return self.handle_error(e, 'creating CrossRef source')
+
+
+class CreateOpenalexSourceInput(BaseModel):
+    """Input schema for creating an OpenAlex source."""
+
+    name: str = Field(description='Unique name for the source')
+    keywords: list[str] = Field(description='Keywords to search for in OpenAlex')
+    max_articles: int = Field(default=50, description='Maximum articles per run')
+    schedule_hours: int = Field(default=24, description='Run interval in hours')
+
+
+class CreateOpenalexSourceTool(BaseThothTool):
+    """Create an OpenAlex discovery source."""
+
+    name: str = 'create_openalex_source'
+    description: str = (
+        'Create an OpenAlex discovery source to automatically find papers. '
+        'Specify name and keywords.'
+    )
+    args_schema: type[BaseModel] = CreateOpenalexSourceInput
+
+    def _run(
+        self,
+        name: str,
+        keywords: list[str],
+        max_articles: int = 50,
+        schedule_hours: int = 24,
+    ) -> str:
+        """Create OpenAlex source."""
+        try:
+            source_config = {
+                'name': name,
+                'source_type': 'api',
+                'description': f'OpenAlex source for {", ".join(keywords)} research',
+                'is_active': True,
+                'api_config': {
+                    'source': 'openalex',
+                    'keywords': keywords,
+                    'sort_by': 'relevance',
+                },
+                'schedule_config': {
+                    'interval_minutes': schedule_hours * 60,
+                    'max_articles_per_run': max_articles,
+                    'enabled': True,
+                },
+                'query_filters': [],
+            }
+
+            if self.adapter.create_discovery_source(source_config):
+                return (
+                    f'✅ **OpenAlex Discovery Source Created Successfully!**\n\n'
+                    f'**Source Details:**\n'
+                    f'- Name: `{name}`\n'
+                    f'- Type: OpenAlex API\n'
+                    f'- Keywords: {", ".join(keywords)}\n'
+                    f'- Schedule: Every {schedule_hours} hours, max {max_articles} articles\n\n'
+                    f'🚀 **Ready to use!**'
+                )
+            else:
+                return f"❌ Failed to create OpenAlex source '{name}'"
+
+        except Exception as e:
+            return self.handle_error(e, 'creating OpenAlex source')
+
+
+class CreateBiorxivSourceInput(BaseModel):
+    """Input schema for creating a bioRxiv source."""
+
+    name: str = Field(description='Unique name for the source')
+    start_date: str | None = Field(default=None, description='Start date YYYY-MM-DD')
+    end_date: str | None = Field(default=None, description='End date YYYY-MM-DD')
+    max_articles: int = Field(default=50, description='Maximum articles per run')
+    schedule_hours: int = Field(default=24, description='Run interval in hours')
+
+
+class CreateBiorxivSourceTool(BaseThothTool):
+    """Create a bioRxiv discovery source."""
+
+    name: str = 'create_biorxiv_source'
+    description: str = (
+        'Create a bioRxiv discovery source to automatically find preprints.'
+    )
+    args_schema: type[BaseModel] = CreateBiorxivSourceInput
+
+    def _run(
+        self,
+        name: str,
+        start_date: str | None = None,
+        end_date: str | None = None,
+        max_articles: int = 50,
+        schedule_hours: int = 24,
+    ) -> str:
+        """Create bioRxiv source."""
+        try:
+            api_config = {
+                'source': 'biorxiv',
+            }
+            if start_date:
+                api_config['start_date'] = start_date
+            if end_date:
+                api_config['end_date'] = end_date
+
+            source_config = {
+                'name': name,
+                'source_type': 'api',
+                'description': 'bioRxiv preprint source',
+                'is_active': True,
+                'api_config': api_config,
+                'schedule_config': {
+                    'interval_minutes': schedule_hours * 60,
+                    'max_articles_per_run': max_articles,
+                    'enabled': True,
+                },
+                'query_filters': [],
+            }
+
+            if self.adapter.create_discovery_source(source_config):
+                return (
+                    f'✅ **bioRxiv Discovery Source Created Successfully!**\n\n'
+                    f'**Source Details:**\n'
+                    f'- Name: `{name}`\n'
+                    f'- Type: bioRxiv API\n'
+                    f'- Schedule: Every {schedule_hours} hours, max {max_articles} articles\n\n'
+                    f'🚀 **Ready to use!**'
+                )
+            else:
+                return f"❌ Failed to create bioRxiv source '{name}'"
+
+        except Exception as e:
+            return self.handle_error(e, 'creating bioRxiv source')
+
+
 class RunDiscoveryInput(BaseModel):
     """Input schema for running discovery."""
 

--- a/src/thoth/services/discovery_service.py
+++ b/src/thoth/services/discovery_service.py
@@ -12,7 +12,13 @@ from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Any
 
-from thoth.discovery.api_sources import ArxivAPISource, PubMedAPISource
+from thoth.discovery.api_sources import (
+    ArxivAPISource,
+    PubMedAPISource,
+    CrossRefAPISource,
+    OpenAlexAPISource,
+    BioRxivAPISource,
+)
 from thoth.discovery.web_scraper import WebScraper
 from thoth.services.base import BaseService, ServiceError
 from thoth.utilities.models import (
@@ -60,6 +66,9 @@ class DiscoveryService(BaseService):
         self.api_sources = {
             'arxiv': ArxivAPISource(),
             'pubmed': PubMedAPISource(),
+            'crossref': CrossRefAPISource(),
+            'openalex': OpenAlexAPISource(),
+            'biorxiv': BioRxivAPISource(),
         }
 
         # Initialize web scraper

--- a/tests/test_ingestion/test_agent_tools.py
+++ b/tests/test_ingestion/test_agent_tools.py
@@ -17,6 +17,9 @@ from thoth.ingestion.agent_v2.tools.analysis_tools import (
 from thoth.ingestion.agent_v2.tools.discovery_tools import (
     CreateArxivSourceTool,
     CreatePubmedSourceTool,
+    CreateCrossrefSourceTool,
+    CreateOpenalexSourceTool,
+    CreateBiorxivSourceTool,
     ListDiscoverySourcesTool,
     RunDiscoveryTool,
 )
@@ -180,6 +183,55 @@ class TestDiscoveryTools:
 
         assert 'Successfully' in result or 'Created' in result
         assert 'pubmed_test' in result
+
+    def test_create_crossref_source_tool(self, mock_adapter):
+        """Test CreateCrossrefSourceTool."""
+        tool = CreateCrossrefSourceTool(adapter=mock_adapter)
+
+        mock_adapter.create_discovery_source.return_value = True
+
+        result = tool._run(
+            name='crossref_test',
+            keywords=['biology'],
+            max_articles=15,
+            schedule_hours=24,
+        )
+
+        assert 'Successfully' in result or 'Created' in result
+        assert 'crossref_test' in result
+
+    def test_create_openalex_source_tool(self, mock_adapter):
+        """Test CreateOpenalexSourceTool."""
+        tool = CreateOpenalexSourceTool(adapter=mock_adapter)
+
+        mock_adapter.create_discovery_source.return_value = True
+
+        result = tool._run(
+            name='openalex_test',
+            keywords=['physics'],
+            max_articles=10,
+            schedule_hours=12,
+        )
+
+        assert 'Successfully' in result or 'Created' in result
+        assert 'openalex_test' in result
+
+    def test_create_biorxiv_source_tool(self, mock_adapter):
+        """Test CreateBiorxivSourceTool."""
+        tool = CreateBiorxivSourceTool(adapter=mock_adapter)
+
+        mock_adapter.create_discovery_source.return_value = True
+
+        result = tool._run(
+            name='biorxiv_test',
+            start_date='2024-01-01',
+            end_date='2024-01-07',
+            max_articles=5,
+            schedule_hours=24,
+        )
+
+        assert 'Successfully' in result or 'Created' in result
+        assert 'biorxiv_test' in result
 
     def test_run_discovery_tool(self, mock_adapter):
         """Test RunDiscoveryTool."""


### PR DESCRIPTION
## Summary
- register OpenAlex and bioRxiv sources in `DiscoveryService`
- add tests for creating OpenAlex and bioRxiv sources via agent tools

## Testing
- `./run_tests.sh all`

------
https://chatgpt.com/codex/tasks/task_e_68444d68d03483248bc913ab21800835