### PR TITLE
Implement structured error handling system

### DIFF
--- a/src/thoth/errors/__init__.py
+++ b/src/thoth/errors/__init__.py
@@ -1,0 +1,19 @@
+"""Thoth error system."""
+
+from thoth.errors.base import (
+    DiscoveryError,
+    ErrorHandler,
+    LLMError,
+    PipelineError,
+    ServiceError,
+    ThothError,
+)
+
+__all__ = [
+    'DiscoveryError',
+    'ErrorHandler',
+    'LLMError',
+    'PipelineError',
+    'ServiceError',
+    'ThothError',
+]

--- a/src/thoth/errors/base.py
+++ b/src/thoth/errors/base.py
@@ -1,0 +1,70 @@
+"""Structured error classes for Thoth."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from loguru import logger
+
+
+class ThothError(Exception):
+    """Base exception for Thoth errors."""
+
+    def __init__(
+        self,
+        error_code: str,
+        message: str,
+        recoverable: bool = False,
+        context: dict[str, Any] | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.error_code = error_code
+        self.message = message
+        self.recoverable = recoverable
+        self.context = context or {}
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize error details to a dictionary."""
+        return {
+            'error_code': self.error_code,
+            'message': self.message,
+            'recoverable': self.recoverable,
+            'context': self.context,
+        }
+
+
+class ServiceError(ThothError):
+    """Error raised for service-related issues."""
+
+
+class PipelineError(ThothError):
+    """Error raised for pipeline failures."""
+
+
+class DiscoveryError(ThothError):
+    """Error raised for discovery problems."""
+
+
+class LLMError(ThothError):
+    """Error raised for LLM processing failures."""
+
+
+class ErrorHandler:
+    """Centralized error handler for Thoth."""
+
+    def __init__(self) -> None:
+        self.errors: list[ThothError] = []
+
+    def handle(self, error: ThothError) -> bool:
+        """Handle an error and return whether it is recoverable."""
+        logger.error(f'{error.error_code}: {error.message}')
+        self.errors.append(error)
+        return error.recoverable
+
+    def serialize_errors(self) -> list[dict[str, Any]]:
+        """Serialize stored errors to a list of dictionaries."""
+        return [err.to_dict() for err in self.errors]
+
+    def clear(self) -> None:
+        """Clear stored errors."""
+        self.errors.clear()

--- a/tests/test_errors/test_base.py
+++ b/tests/test_errors/test_base.py
@@ -1,0 +1,45 @@
+"""Tests for Thoth error system."""
+
+from thoth.errors import ErrorHandler, PipelineError, ServiceError, ThothError
+
+
+def test_error_creation_and_properties() -> None:
+    """Ensure errors store provided properties."""
+    err = ThothError(
+        error_code='E001',
+        message='Test error',
+        recoverable=True,
+        context={'foo': 'bar'},
+    )
+
+    assert err.error_code == 'E001'
+    assert err.message == 'Test error'
+    assert err.recoverable is True
+    assert err.context == {'foo': 'bar'}
+
+
+def test_error_serialization() -> None:
+    """Errors should serialize to dictionaries."""
+    err = ServiceError('S001', 'Service failed')
+    result = err.to_dict()
+
+    assert result['error_code'] == 'S001'
+    assert result['message'] == 'Service failed'
+    assert result['recoverable'] is False
+    assert result['context'] == {}
+
+
+def test_error_handler_functionality() -> None:
+    """ErrorHandler should record and serialize errors."""
+    handler = ErrorHandler()
+    err = PipelineError('P001', 'Pipeline issue', recoverable=True)
+
+    is_recoverable = handler.handle(err)
+    assert is_recoverable is True
+    assert handler.errors == [err]
+
+    serialized = handler.serialize_errors()
+    assert serialized == [err.to_dict()]
+
+    handler.clear()
+    assert handler.errors == []


### PR DESCRIPTION
## Summary
- add `ThothError` base class with serialization helpers
- implement specific error types: `ServiceError`, `PipelineError`, `DiscoveryError`, `LLMError`
- create `ErrorHandler` for centralized error management
- test error creation, handler behavior and serialization

## Testing
- `ruff format src/thoth/errors/base.py tests/test_errors/test_base.py src/thoth/errors/__init__.py`
- `ruff check src/thoth/errors/base.py tests/test_errors/test_base.py src/thoth/errors/__init__.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ce1e035948324a32e220a04aa595b