### PR TITLE
Feature: Add health check system for all services

### DIFF
--- a/src/thoth/monitoring/__init__.py
+++ b/src/thoth/monitoring/__init__.py
@@ -1,0 +1,1 @@
+from .health import HealthMonitor

--- a/src/thoth/monitoring/health.py
+++ b/src/thoth/monitoring/health.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+"""Simple health monitoring utilities."""
+
+from typing import Any, Dict
+
+from thoth.services.service_manager import ServiceManager
+
+
+class HealthMonitor:
+    """Collect health information for all services."""
+
+    def __init__(self, service_manager: ServiceManager) -> None:
+        self.service_manager = service_manager
+
+    def check_services(self) -> Dict[str, Dict[str, Any]]:
+        """Run ``health_check`` on all managed services."""
+        statuses: Dict[str, Dict[str, Any]] = {}
+        for name, service in self.service_manager.get_all_services().items():
+            try:
+                statuses[name] = service.health_check()
+            except Exception as exc:  # pragma: no cover - defensive
+                statuses[name] = {
+                    'service': service.__class__.__name__,
+                    'status': 'unhealthy',
+                    'error': str(exc),
+                }
+        return statuses
+
+    def overall_status(self) -> Dict[str, Any]:
+        """Return aggregated health information."""
+        services = self.check_services()
+        healthy = all(info.get('status') == 'healthy' for info in services.values())
+        return {'healthy': healthy, 'services': services}

--- a/src/thoth/server/api_server.py
+++ b/src/thoth/server/api_server.py
@@ -22,6 +22,7 @@ from starlette.middleware.cors import CORSMiddleware
 from thoth.ingestion.pdf_downloader import download_pdf
 from thoth.services.llm_router import LLMRouter
 from thoth.utilities.config import get_config
+from thoth.monitoring import HealthMonitor
 
 app = FastAPI(
     title='Thoth Obsidian Integration',
@@ -44,6 +45,9 @@ pdf_dir: Path = None
 notes_dir: Path = None
 base_url: str = None
 current_config: dict[str, Any] = {}
+
+# Service manager initialized when the server starts
+service_manager = None
 
 # Global agent instance - will be initialized when server starts
 research_agent = None
@@ -94,8 +98,13 @@ class AgentRestartRequest(BaseModel):
 
 @app.get('/health')
 def health_check():
-    """Health check endpoint."""
-    return JSONResponse({'status': 'healthy', 'service': 'thoth-obsidian-api'})
+    """Health check endpoint returning service statuses."""
+    global service_manager
+    if service_manager is None:
+        return JSONResponse({'status': 'uninitialized'})
+
+    monitor = HealthMonitor(service_manager)
+    return JSONResponse(monitor.overall_status())
 
 
 @app.get('/download-pdf')
@@ -474,7 +483,7 @@ async def delayed_shutdown():
 
 async def reinitialize_agent():
     """Reinitialize the agent without restarting the process."""
-    global research_agent, agent_adapter, llm_router
+    global research_agent, agent_adapter, llm_router, service_manager
 
     try:
         logger.info('Reinitializing research agent...')
@@ -577,7 +586,7 @@ def start_server(
         pipeline (ThothPipeline | None): Optional ThothPipeline instance.
         reload (bool): Whether to enable auto-reload for development.
     """
-    global pdf_dir, notes_dir, base_url, research_agent, agent_adapter, llm_router
+    global pdf_dir, notes_dir, base_url, research_agent, agent_adapter, llm_router, service_manager
 
     # Set module-level configuration
     pdf_dir = pdf_directory

--- a/src/thoth/services/article_service.py
+++ b/src/thoth/services/article_service.py
@@ -309,3 +309,7 @@ class ArticleService(BaseService):
             return 0.0
         confidences = [eval.confidence for _, eval in evaluations]
         return sum(confidences) / len(confidences)
+
+    def health_check(self) -> dict[str, str]:
+        """Basic health status for the ArticleService."""
+        return super().health_check()

--- a/src/thoth/services/base.py
+++ b/src/thoth/services/base.py
@@ -100,3 +100,10 @@ class BaseService(ABC):
             **details: Additional details to log
         """
         self.logger.info(f'{operation}', **details)
+
+    def health_check(self) -> dict[str, str]:
+        """Return basic health status for the service."""
+        return {
+            'service': self.__class__.__name__,
+            'status': 'healthy',
+        }

--- a/src/thoth/services/citation_service.py
+++ b/src/thoth/services/citation_service.py
@@ -487,3 +487,7 @@ class CitationService(BaseService):
                 self.handle_error(e, f"locating PDF for '{citation.title[:50]}'")
             )
             return None
+
+    def health_check(self) -> dict[str, str]:
+        """Basic health status for the CitationService."""
+        return super().health_check()

--- a/src/thoth/services/discovery_service.py
+++ b/src/thoth/services/discovery_service.py
@@ -774,3 +774,7 @@ class DiscoveryService(BaseService):
                 json.dump(self.schedule_state, f, indent=2)
         except Exception as e:
             self.logger.error(f'Error saving schedule state: {e}')
+
+    def health_check(self) -> dict[str, str]:
+        """Basic health status for the DiscoveryService."""
+        return super().health_check()

--- a/src/thoth/services/llm_router.py
+++ b/src/thoth/services/llm_router.py
@@ -176,3 +176,7 @@ class LLMRouter(BaseService):
     def get_models(self) -> list[dict]:
         """Gets the list of available models from OpenRouter."""
         return get_openrouter_models()
+
+    def health_check(self) -> dict[str, str]:
+        """Basic health status for the LLMRouter."""
+        return super().health_check()

--- a/src/thoth/services/llm_service.py
+++ b/src/thoth/services/llm_service.py
@@ -368,3 +368,7 @@ class LLMService(BaseService):
         self._clients.clear()
 
         self.log_operation('cache_cleared', count=len(self._clients))
+
+    def health_check(self) -> dict[str, str]:
+        """Basic health status for the LLMService."""
+        return super().health_check()

--- a/src/thoth/services/note_service.py
+++ b/src/thoth/services/note_service.py
@@ -443,3 +443,7 @@ class NoteService(BaseService):
         except Exception as e:
             self.logger.error(self.handle_error(e, 'getting note statistics'))
             return {}
+
+    def health_check(self) -> dict[str, str]:
+        """Basic health status for the NoteService."""
+        return super().health_check()

--- a/src/thoth/services/pdf_locator_service.py
+++ b/src/thoth/services/pdf_locator_service.py
@@ -416,3 +416,7 @@ class PdfLocatorService(BaseService):
                     return 'cc-by-nd'
 
         return None
+
+    def health_check(self) -> dict[str, str]:
+        """Basic health status for the PdfLocatorService."""
+        return super().health_check()

--- a/src/thoth/services/processing_service.py
+++ b/src/thoth/services/processing_service.py
@@ -441,3 +441,7 @@ class ProcessingService(BaseService):
         except Exception as e:
             self.logger.error(self.handle_error(e, 'getting processing stats'))
             return {}
+
+    def health_check(self) -> dict[str, str]:
+        """Basic health status for the ProcessingService."""
+        return super().health_check()

--- a/src/thoth/services/query_service.py
+++ b/src/thoth/services/query_service.py
@@ -298,3 +298,7 @@ class QueryService(BaseService):
     def initialize(self) -> None:
         """Initialize the query service."""
         self.logger.info('Query service initialized')
+
+    def health_check(self) -> dict[str, str]:
+        """Basic health status for the QueryService."""
+        return super().health_check()

--- a/src/thoth/services/rag_service.py
+++ b/src/thoth/services/rag_service.py
@@ -349,3 +349,7 @@ class RAGService(BaseService):
 
         except Exception as e:
             raise ServiceError(self.handle_error(e, 'indexing knowledge base')) from e
+
+    def health_check(self) -> dict[str, str]:
+        """Basic health status for the RAGService."""
+        return super().health_check()

--- a/src/thoth/services/tag_service.py
+++ b/src/thoth/services/tag_service.py
@@ -511,3 +511,7 @@ class TagService(BaseService):
             'articles_updated': articles_updated,
             'tags_added': total_tags_added,
         }
+
+    def health_check(self) -> dict[str, str]:
+        """Basic health status for the TagService."""
+        return super().health_check()

--- a/src/thoth/services/web_search_service.py
+++ b/src/thoth/services/web_search_service.py
@@ -80,3 +80,7 @@ class WebSearchService(BaseService):
             raise ServiceError('No available web search providers')
         except Exception as e:
             raise ServiceError(self.handle_error(e, 'web searching')) from e
+
+    def health_check(self) -> dict[str, str]:
+        """Basic health status for the WebSearchService."""
+        return super().health_check()

--- a/tests/monitoring/test_health.py
+++ b/tests/monitoring/test_health.py
@@ -1,0 +1,49 @@
+"""Tests for service health monitoring."""
+
+import json
+
+from thoth.monitoring import HealthMonitor
+from thoth.services.service_manager import ServiceManager
+from thoth.server.api_server import health_check
+
+
+def _create_manager() -> ServiceManager:
+    manager = ServiceManager()
+    manager.initialize()
+    return manager
+
+
+def test_individual_service_health():
+    manager = _create_manager()
+    for service in manager.get_all_services().values():
+        status = service.health_check()
+        assert status["status"] == "healthy"
+
+
+def test_health_monitor_overall():
+    manager = _create_manager()
+    monitor = HealthMonitor(manager)
+    result = monitor.overall_status()
+    assert result["healthy"] is True
+    assert set(result["services"].keys()) == set(manager.get_all_services().keys())
+
+
+def test_health_endpoint(monkeypatch):
+    manager = _create_manager()
+    monkeypatch.setattr('thoth.server.api_server.service_manager', manager, raising=False)
+    response = health_check()
+    data = json.loads(response.body.decode())
+    assert data["healthy"] is True
+    assert "services" in data
+
+
+def test_health_monitor_failure(monkeypatch):
+    manager = _create_manager()
+    svc_name, svc = next(iter(manager.get_all_services().items()))
+    def boom():
+        raise RuntimeError('fail')
+    monkeypatch.setattr(svc, 'health_check', boom)
+    monitor = HealthMonitor(manager)
+    result = monitor.overall_status()
+    assert result["healthy"] is False
+    assert result["services"][svc_name]["status"] == "unhealthy"


### PR DESCRIPTION
## Summary
- implement `health_check` in `BaseService`
- add `health_check` implementations to each service
- add `HealthMonitor` for aggregated status
- expose `/health` endpoint with detailed status
- test monitoring behaviour and endpoint

## Testing
- `bash run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_684ce2406ff48324a9ebdf42c29f6045