### PR TITLE
Extract KnowledgePipeline for RAG operations

### DIFF
--- a/src/thoth/cli/rag.py
+++ b/src/thoth/cli/rag.py
@@ -11,7 +11,7 @@ def run_rag_index(args, pipeline: ThothPipeline):
         logger.warning('Force flag enabled - will reindex all documents')
     try:
         logger.info('Starting knowledge base indexing for RAG system...')
-        stats = pipeline.index_knowledge_base()
+        stats = pipeline.knowledge_pipeline.index_knowledge_base()
         logger.info('Knowledge base indexing completed:')
         logger.info(f'  Total files indexed: {stats["total_files"]}')
         logger.info(f'  - Markdown files: {stats["markdown_files"]}')
@@ -40,7 +40,7 @@ def run_rag_search(args, pipeline: ThothPipeline):
         filter_dict = None
         if args.filter_type != 'all':
             filter_dict = {'document_type': args.filter_type}
-        results = pipeline.search_knowledge_base(
+        results = pipeline.knowledge_pipeline.search_knowledge_base(
             query=args.query,
             k=args.k,
             filter=filter_dict,
@@ -69,7 +69,7 @@ def run_rag_ask(args, pipeline: ThothPipeline):
     """
     try:
         logger.info(f'Asking question: {args.question}')
-        response = pipeline.ask_knowledge_base(
+        response = pipeline.knowledge_pipeline.ask_knowledge_base(
             question=args.question,
             k=args.k,
         )
@@ -97,7 +97,7 @@ def run_rag_stats(args, pipeline: ThothPipeline):
         logger.info('Verbose mode enabled - showing detailed statistics')
     try:
         logger.info('RAG System Statistics:')
-        stats = pipeline.get_rag_stats()
+        stats = pipeline.knowledge_pipeline.get_rag_stats()
         logger.info(f'  Documents indexed: {stats.get("document_count", 0)}')
         logger.info(f'  Collection name: {stats.get("collection_name", "Unknown")}')
         logger.info(f'  Embedding model: {stats.get("embedding_model", "Unknown")}')
@@ -126,7 +126,7 @@ def run_rag_clear(args, pipeline: ThothPipeline):
                 logger.info('Clear operation cancelled.')
                 return 0
         logger.warning('Clearing RAG vector index...')
-        pipeline.clear_rag_index()
+        pipeline.knowledge_pipeline.clear_rag_index()
         logger.info('RAG vector index cleared successfully.')
         logger.info('Run "thoth rag index" to re-index your knowledge base.')
         return 0

--- a/src/thoth/pipeline.py
+++ b/src/thoth/pipeline.py
@@ -17,6 +17,7 @@ from loguru import logger
 
 from thoth.knowledge.graph import CitationGraph
 from thoth.pipelines.document_pipeline import DocumentPipeline
+from thoth.pipelines.knowledge_pipeline import KnowledgePipeline
 from thoth.server.pdf_monitor import PDFTracker
 from thoth.services.service_manager import ServiceManager
 from thoth.utilities.config import get_config
@@ -114,6 +115,16 @@ class ThothPipeline:
             markdown_dir=self.markdown_dir,
         )
 
+        # Initialize knowledge pipeline for RAG operations
+        self.knowledge_pipeline = KnowledgePipeline(
+            services=self.services,
+            citation_tracker=self.citation_tracker,
+            pdf_tracker=self.pdf_tracker,
+            output_dir=self.output_dir,
+            notes_dir=self.notes_dir,
+            markdown_dir=self.markdown_dir,
+        )
+
         logger.info('Thoth pipeline initialized with service layer')
 
     def process_pdf(self, pdf_path: str | Path):
@@ -123,20 +134,6 @@ class ThothPipeline:
             return self.document_pipeline.process_pdf(pdf_path)
         except Exception as e:  # pragma: no cover - should be rare
             raise PipelineError(str(e)) from e
-
-    def _index_to_rag(self, file_path: Path) -> None:
-        """
-        Index a file to the RAG system if available.
-
-        Args:
-            file_path: Path to the file to index.
-        """
-        try:
-            if file_path.exists() and file_path.suffix == '.md':
-                self.services.rag.index_file(file_path)
-                logger.debug(f'Indexed {file_path} to RAG system')
-        except Exception as e:
-            logger.debug(f'Failed to index {file_path} to RAG: {e}')
 
     def regenerate_all_notes(self) -> list[tuple[Path, Path]]:
         """
@@ -262,105 +259,6 @@ class ThothPipeline:
 
         return self.services.tag.consolidate_and_retag()
 
-    def index_knowledge_base(self) -> dict[str, Any]:
-        """
-        Index all markdown files in the knowledge base into the RAG system.
-
-        This method indexes:
-        - All markdown files in the markdown directory (OCR'd articles)
-        - All markdown files in the notes directory (generated notes)
-
-        Returns:
-            dict[str, Any]: Summary statistics of the indexing process,
-                           including counts of files indexed and any errors.
-
-        Example:
-            >>> pipeline = ThothPipeline()
-            >>> stats = pipeline.index_knowledge_base()
-            >>> print(f'Indexed {stats["total_files"]} files')
-        """
-        logger.info('Starting knowledge base indexing for RAG system')
-
-        try:
-            stats = self.services.rag.index_knowledge_base()
-
-            logger.info(
-                f'Knowledge base indexing completed. '
-                f'Indexed {stats["total_files"]} files '
-                f'({stats["total_chunks"]} chunks)'
-            )
-
-            return stats
-
-        except Exception as e:
-            logger.error(f'Knowledge base indexing failed: {e}')
-            raise PipelineError(f'Knowledge base indexing failed: {e}') from e
-
-    def search_knowledge_base(
-        self,
-        query: str,
-        k: int = 4,
-        filter: dict[str, Any] | None = None,
-    ) -> list[dict[str, Any]]:
-        """
-        Search the knowledge base for relevant documents.
-
-        Args:
-            query: Search query text.
-            k: Number of results to return.
-            filter: Optional metadata filter (e.g., {'document_type': 'note'}).
-
-        Returns:
-            list[dict[str, Any]]: List of search results with content and metadata.
-
-        Example:
-            >>> pipeline = ThothPipeline()
-            >>> results = pipeline.search_knowledge_base('transformer architecture')
-            >>> for result in results:
-            ...     print(f'Score: {result["score"]}, Title: {result["title"]}')
-        """
-        try:
-            logger.info(f'Searching knowledge base for: {query}')
-            return self.services.rag.search(query, k, filter)
-
-        except Exception as e:
-            logger.error(f'Knowledge base search failed: {e}')
-            raise PipelineError(f'Knowledge base search failed: {e}') from e
-
-    def ask_knowledge_base(
-        self,
-        question: str,
-        k: int = 4,
-        filter: dict[str, Any] | None = None,
-    ) -> dict[str, Any]:
-        """
-        Ask a question and get an answer based on the knowledge base.
-
-        Args:
-            question: The question to ask.
-            k: Number of documents to retrieve for context.
-            filter: Optional metadata filter for retrieval.
-
-        Returns:
-            dict[str, Any]: Answer with sources and metadata.
-
-        Example:
-            >>> pipeline = ThothPipeline()
-            >>> response = pipeline.ask_knowledge_base(
-            ...     'What are the main contributions of the transformer paper?'
-            ... )
-            >>> print(response['answer'])
-            >>> for source in response['sources']:
-            ...     print(f'Source: {source["metadata"]["title"]}')
-        """
-        try:
-            logger.info(f'Answering question: {question}')
-            return self.services.rag.ask_question(question, k, filter)
-
-        except Exception as e:
-            logger.error(f'Failed to answer question: {e}')
-            raise PipelineError(f'Failed to answer question: {e}') from e
-
     def web_search(
         self, query: str, num_results: int = 5, provider: str | None = None
     ) -> list[SearchResult]:
@@ -374,43 +272,6 @@ class ThothPipeline:
             logger.error(f'Web search failed: {e}')
             raise PipelineError(f'Web search failed: {e}') from e
 
-    def clear_rag_index(self) -> None:
-        """
-        Clear the entire RAG vector index.
-
-        WARNING: This will delete all indexed documents and require re-indexing.
-
-        Example:
-            >>> pipeline = ThothPipeline()
-            >>> pipeline.clear_rag_index()
-            >>> # Now re-index
-            >>> pipeline.index_knowledge_base()
-        """
-        try:
-            logger.warning('Clearing RAG vector index')
-            self.services.rag.clear_index()
-            logger.info('RAG vector index cleared successfully')
-        except Exception as e:
-            logger.error(f'Failed to clear RAG index: {e}')
-            raise PipelineError(f'Failed to clear RAG index: {e}') from e
-
-    def get_rag_stats(self) -> dict[str, Any]:
-        """
-        Get statistics about the RAG system.
-
-        Returns:
-            dict[str, Any]: Statistics including document count, models used, etc.
-
-        Example:
-            >>> pipeline = ThothPipeline()
-            >>> stats = pipeline.get_rag_stats()
-            >>> print(f'Documents indexed: {stats["document_count"]}')
-        """
-        try:
-            return self.services.rag.get_stats()
-        except Exception as e:
-            logger.error(f'Failed to get RAG stats: {e}')
-            raise PipelineError(f'Failed to get RAG stats: {e}') from e
 
 
 # Example usage

--- a/src/thoth/pipelines/__init__.py
+++ b/src/thoth/pipelines/__init__.py
@@ -2,5 +2,6 @@
 
 from .base import BasePipeline
 from .document_pipeline import DocumentPipeline
+from .knowledge_pipeline import KnowledgePipeline
 
-__all__ = ['BasePipeline', 'DocumentPipeline']
+__all__ = ['BasePipeline', 'DocumentPipeline', 'KnowledgePipeline']

--- a/src/thoth/pipelines/knowledge_pipeline.py
+++ b/src/thoth/pipelines/knowledge_pipeline.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from loguru import logger
+
+from .base import BasePipeline
+
+
+class KnowledgePipeline(BasePipeline):
+    """Pipeline for managing knowledge base and RAG operations."""
+
+    def _index_to_rag(self, file_path: Path) -> None:
+        """Index a markdown file to the RAG system if available."""
+        try:
+            if file_path.exists() and file_path.suffix == ".md":
+                self.services.rag.index_file(file_path)
+                logger.debug(f"Indexed {file_path} to RAG system")
+        except Exception as e:  # pragma: no cover - optional integration
+            logger.debug(f"Failed to index {file_path} to RAG: {e}")
+
+    def index_knowledge_base(self) -> dict[str, Any]:
+        """Index all markdown and note files into the RAG system."""
+        logger.info("Starting knowledge base indexing for RAG system")
+        try:
+            stats = self.services.rag.index_knowledge_base()
+            logger.info(
+                f"Knowledge base indexing completed. "
+                f"Indexed {stats['total_files']} files "
+                f"({stats['total_chunks']} chunks)"
+            )
+            return stats
+        except Exception as e:
+            logger.error(f"Knowledge base indexing failed: {e}")
+            raise
+
+    def search_knowledge_base(
+        self, query: str, k: int = 4, filter: dict[str, Any] | None = None
+    ) -> list[dict[str, Any]]:
+        """Search the knowledge base for relevant documents."""
+        try:
+            logger.info(f"Searching knowledge base for: {query}")
+            return self.services.rag.search(query, k, filter)
+        except Exception as e:
+            logger.error(f"Knowledge base search failed: {e}")
+            raise
+
+    def ask_knowledge_base(
+        self, question: str, k: int = 4, filter: dict[str, Any] | None = None
+    ) -> dict[str, Any]:
+        """Ask a question using the knowledge base."""
+        try:
+            logger.info(f"Answering question: {question}")
+            return self.services.rag.ask_question(question, k, filter)
+        except Exception as e:
+            logger.error(f"Failed to answer question: {e}")
+            raise
+
+    def clear_rag_index(self) -> None:
+        """Clear the entire RAG vector index."""
+        try:
+            logger.warning("Clearing RAG vector index")
+            self.services.rag.clear_index()
+            logger.info("RAG vector index cleared successfully")
+        except Exception as e:
+            logger.error(f"Failed to clear RAG index: {e}")
+            raise
+
+    def get_rag_stats(self) -> dict[str, Any]:
+        """Get statistics about the RAG system."""
+        try:
+            return self.services.rag.get_stats()
+        except Exception as e:
+            logger.error(f"Failed to get RAG stats: {e}")
+            raise

--- a/tests/pipelines/test_knowledge_pipeline.py
+++ b/tests/pipelines/test_knowledge_pipeline.py
@@ -1,0 +1,89 @@
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from thoth.pipelines.knowledge_pipeline import KnowledgePipeline
+
+
+class TestKnowledgePipeline:
+    @pytest.fixture
+    def knowledge_pipeline(self, temp_workspace):
+        pipeline = KnowledgePipeline(
+            services=MagicMock(),
+            citation_tracker=MagicMock(),
+            pdf_tracker=MagicMock(),
+            output_dir=temp_workspace / "output",
+            notes_dir=temp_workspace / "notes",
+            markdown_dir=temp_workspace / "markdown",
+        )
+        return pipeline
+
+    def test_index_to_rag(self, knowledge_pipeline, temp_workspace):
+        md_file = temp_workspace / "markdown" / "file.md"
+        md_file.write_text("data")
+        knowledge_pipeline._index_to_rag(md_file)
+        knowledge_pipeline.services.rag.index_file.assert_called_once_with(md_file)
+
+    def test_index_knowledge_base(self, knowledge_pipeline):
+        with patch.object(
+            knowledge_pipeline.services.rag, "index_knowledge_base"
+        ) as mock_index:
+            mock_index.return_value = {
+                "total_files": 2,
+                "markdown_files": 1,
+                "note_files": 1,
+                "total_chunks": 2,
+                "errors": [],
+            }
+            stats = knowledge_pipeline.index_knowledge_base()
+            assert stats["total_files"] == 2
+            assert stats["markdown_files"] == 1
+            mock_index.assert_called_once()
+
+    def test_search_knowledge_base(self, knowledge_pipeline):
+        with patch.object(knowledge_pipeline.services.rag, "search") as mock_search:
+            mock_search.return_value = [
+                {
+                    "content": "Test content",
+                    "title": "Doc",
+                    "document_type": "note",
+                    "score": 0.8,
+                }
+            ]
+            results = knowledge_pipeline.search_knowledge_base("query", k=3)
+            assert len(results) == 1
+            assert results[0]["title"] == "Doc"
+            mock_search.assert_called_once()
+
+    def test_ask_knowledge_base(self, knowledge_pipeline):
+        with patch.object(
+            knowledge_pipeline.services.rag, "ask_question"
+        ) as mock_ask:
+            mock_ask.return_value = {
+                "question": "Q",
+                "answer": "A",
+                "sources": [
+                    {"page_content": "c", "metadata": {"title": "Doc"}}
+                ],
+            }
+            resp = knowledge_pipeline.ask_knowledge_base("Q")
+            assert resp["question"] == "Q"
+            assert "A" in resp["answer"]
+            mock_ask.assert_called_once()
+
+    def test_clear_rag_index(self, knowledge_pipeline):
+        with patch.object(
+            knowledge_pipeline.services.rag, "clear_index"
+        ) as mock_clear:
+            knowledge_pipeline.clear_rag_index()
+            mock_clear.assert_called_once()
+
+    def test_get_rag_stats(self, knowledge_pipeline):
+        with patch.object(
+            knowledge_pipeline.services.rag, "get_stats"
+        ) as mock_stats:
+            mock_stats.return_value = {"document_count": 1}
+            stats = knowledge_pipeline.get_rag_stats()
+            assert stats["document_count"] == 1
+            mock_stats.assert_called_once()

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -137,7 +137,7 @@ class TestThothPipeline:
                 'errors': [],
             }
 
-            stats = pipeline.index_knowledge_base()
+            stats = pipeline.knowledge_pipeline.index_knowledge_base()
 
             assert stats['total_files'] == 2
             assert stats['markdown_files'] == 1
@@ -157,7 +157,7 @@ class TestThothPipeline:
                 }
             ]
 
-            results = pipeline.search_knowledge_base(query, k=5)
+            results = pipeline.knowledge_pipeline.search_knowledge_base(query, k=5)
 
             assert len(results) == 1
             assert results[0]['title'] == 'Test Document'
@@ -179,7 +179,7 @@ class TestThothPipeline:
                 ],
             }
 
-            response = pipeline.ask_knowledge_base(question)
+            response = pipeline.knowledge_pipeline.ask_knowledge_base(question)
 
             assert response['question'] == question
             assert 'Machine learning is' in response['answer']


### PR DESCRIPTION
## Summary
- add `KnowledgePipeline` dedicated to RAG operations
- wire `ThothPipeline` to use the new `KnowledgePipeline`
- update CLI to call through `KnowledgePipeline`
- adjust tests and add coverage for the new pipeline

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ce70fa87083248ae397d9058b9852