### PR TITLE
Add LLM factory for client creation

### DIFF
--- a/src/thoth/services/llm/factory.py
+++ b/src/thoth/services/llm/factory.py
@@ -1,0 +1,32 @@
+"""Factory for creating LLM clients."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+from thoth.utilities import AnthropicClient, OpenAIClient, OpenRouterClient
+
+from .protocols import UnifiedLLMClient
+
+
+class LLMFactory:
+    """Factory class for creating LLM clients."""
+
+    def __init__(self) -> None:
+        self._registry: dict[str, Callable[[dict], UnifiedLLMClient]] = {
+            'openrouter': lambda cfg: OpenRouterClient(**cfg),
+            'openai': lambda cfg: OpenAIClient(**cfg),
+            'anthropic': lambda cfg: AnthropicClient(**cfg),
+        }
+
+    def register_provider(
+        self, provider: str, constructor: Callable[[dict], UnifiedLLMClient]
+    ) -> None:
+        """Register a new provider with its constructor."""
+        self._registry[provider] = constructor
+
+    def create_client(self, provider: str, config: dict) -> UnifiedLLMClient:
+        """Create a client for the given provider using provided config."""
+        if provider not in self._registry:
+            raise ValueError(f"Unknown provider '{provider}'")
+        return self._registry[provider](config)

--- a/src/thoth/services/llm_service.py
+++ b/src/thoth/services/llm_service.py
@@ -11,11 +11,8 @@ from langchain_core.prompts import ChatPromptTemplate
 from pydantic import BaseModel
 
 from thoth.services.base import BaseService, ServiceError
-from thoth.utilities import (
-    OpenRouterClient,
-)
-from thoth.utilities.anthropic_client import AnthropicClient
-from thoth.utilities.openai_client import OpenAIClient
+from thoth.services.llm.factory import LLMFactory
+from thoth.services.llm.protocols import UnifiedLLMClient
 
 
 class LLMService(BaseService):
@@ -41,10 +38,24 @@ class LLMService(BaseService):
         self._clients = {}  # Cache for different model clients
         self._structured_clients: dict[str, Any] = {}
         self._prompt_templates: dict[str, ChatPromptTemplate] = {}
+        self.factory = LLMFactory()
 
     def initialize(self) -> None:
         """Initialize the LLM service."""
         self.logger.info('LLM service initialized')
+
+    def _get_client(
+        self,
+        provider: str,
+        **config: Any,
+    ) -> UnifiedLLMClient:
+        """Create a client using the LLM factory."""
+        try:
+            return self.factory.create_client(provider, config)
+        except Exception as e:
+            raise ServiceError(
+                self.handle_error(e, f"creating client for provider '{provider}'")
+            ) from e
 
     def get_client(
         self,
@@ -95,37 +106,25 @@ class LLMService(BaseService):
             model_kwargs.pop('max_tokens', None)
             model_kwargs.pop('use_rate_limiter', None)
 
-            provider, model_name = (
-                model.split('/', 1) if '/' in model else (None, model)
+            provider, _ = model.split('/', 1) if '/' in model else (None, model)
+
+            cfg = dict(
+                model=model,
+                temperature=temperature,
+                max_tokens=max_tokens,
+                use_rate_limiter=use_rate_limiter,
+                **model_kwargs,
             )
 
             if provider == 'openai' and self.config.api_keys.openai_key:
-                client = OpenAIClient(
-                    api_key=self.config.api_keys.openai_key,
-                    model=model,
-                    temperature=temperature,
-                    max_tokens=max_tokens,
-                    use_rate_limiter=use_rate_limiter,
-                    **model_kwargs,
-                )
+                cfg['api_key'] = self.config.api_keys.openai_key
             elif provider == 'anthropic' and self.config.api_keys.anthropic_key:
-                client = AnthropicClient(
-                    api_key=self.config.api_keys.anthropic_key,
-                    model=model,
-                    temperature=temperature,
-                    max_tokens=max_tokens,
-                    use_rate_limiter=use_rate_limiter,
-                    **model_kwargs,
-                )
+                cfg['api_key'] = self.config.api_keys.anthropic_key
             else:
-                client = OpenRouterClient(
-                    api_key=self.config.api_keys.openrouter_key,
-                    model=model,
-                    temperature=temperature,
-                    max_tokens=max_tokens,
-                    use_rate_limiter=use_rate_limiter,
-                    **model_kwargs,
-                )
+                provider = 'openrouter'
+                cfg['api_key'] = self.config.api_keys.openrouter_key
+
+            client = self._get_client(provider, **cfg)
 
             # Cache and return
             self._clients[cache_key] = client

--- a/tests/services/llm/test_factory.py
+++ b/tests/services/llm/test_factory.py
@@ -1,0 +1,51 @@
+import pytest
+
+from thoth.services.llm.factory import LLMFactory
+from thoth.utilities.anthropic_client import AnthropicClient
+from thoth.utilities.openai_client import OpenAIClient
+from thoth.utilities.openrouter import OpenRouterClient
+
+
+def test_create_clients(monkeypatch):
+    monkeypatch.setenv('OPENAI_API_KEY', 'x')
+    monkeypatch.setenv('ANTHROPIC_API_KEY', 'x')
+    monkeypatch.setenv('OPENROUTER_API_KEY', 'x')
+    factory = LLMFactory()
+
+    assert isinstance(
+        factory.create_client('openai', {'api_key': 'x', 'model': 'openai/gpt-4'}),
+        OpenAIClient,
+    )
+    assert isinstance(
+        factory.create_client(
+            'anthropic',
+            {
+                'api_key': 'x',
+                'model': 'anthropic/claude-3-haiku',
+                'max_tokens': 1,
+            },
+        ),
+        AnthropicClient,
+    )
+    assert isinstance(
+        factory.create_client(
+            'openrouter', {'api_key': 'x', 'model': 'openai/gpt-4o-mini'}
+        ),
+        OpenRouterClient,
+    )
+
+
+def test_unknown_provider():
+    factory = LLMFactory()
+    with pytest.raises(ValueError):
+        factory.create_client('unknown', {})
+
+
+def test_config_passing(monkeypatch):
+    monkeypatch.setenv('OPENAI_API_KEY', 'x')
+    factory = LLMFactory()
+    client = factory.create_client(
+        'openai', {'api_key': 'x', 'model': 'openai/gpt-4o-mini', 'temperature': 0.5}
+    )
+    assert client.temperature == 0.5
+    assert client.model_name == 'openai/gpt-4o-mini'

--- a/tests/test_services/test_llm_service.py
+++ b/tests/test_services/test_llm_service.py
@@ -30,7 +30,7 @@ def test_get_client_openai_native(thoth_config: ThothConfig, monkeypatch):
     thoth_config.api_keys.openai_key = 'fake-key'
     llm_service = LLMService(config=thoth_config)
 
-    with patch('thoth.services.llm_service.OpenAIClient') as mock_openai:
+    with patch('thoth.services.llm.factory.OpenAIClient') as mock_openai:
         llm_service.get_client(model='openai/gpt-4o')
         mock_openai.assert_called_once()
 
@@ -41,7 +41,7 @@ def test_get_client_anthropic_native(thoth_config: ThothConfig, monkeypatch):
     thoth_config.api_keys.anthropic_key = 'fake-key'
     llm_service = LLMService(config=thoth_config)
 
-    with patch('thoth.services.llm_service.AnthropicClient') as mock_anthropic:
+    with patch('thoth.services.llm.factory.AnthropicClient') as mock_anthropic:
         llm_service.get_client(model='anthropic/claude-3-haiku')
         mock_anthropic.assert_called_once()
 
@@ -49,7 +49,7 @@ def test_get_client_anthropic_native(thoth_config: ThothConfig, monkeypatch):
 def test_get_client_openrouter_fallback(thoth_config: ThothConfig):
     """Test that OpenRouter is used as a fallback."""
     llm_service = LLMService(config=thoth_config)
-    with patch('thoth.services.llm_service.OpenRouterClient') as mock_openrouter:
+    with patch('thoth.services.llm.factory.OpenRouterClient') as mock_openrouter:
         llm_service.get_client(model='some/other-model')
         mock_openrouter.assert_called_once()
 


### PR DESCRIPTION
## Summary
- implement `LLMFactory` for instantiating LLM clients
- refactor `LLMService` to create clients via the new factory
- add tests for the factory and update existing service tests

## Testing
- `ruff check`
- `pytest tests/services/llm/test_factory.py tests/test_services/test_llm_service.py -q`

------
https://chatgpt.com/codex/tasks/task_e_684ce740b3cc8324b3311aa8f70cc17e