### PR TITLE
Refactor: Convert ArxivAPISource to discovery plugin

### DIFF
--- a/src/thoth/discovery/__init__.py
+++ b/src/thoth/discovery/__init__.py
@@ -6,6 +6,7 @@ various sources like ArXiv, PubMed, and web scrapers.
 """
 
 from .api_sources import ArxivAPISource, PubMedAPISource
+from .plugins import ArxivPlugin, plugin_registry
 from .discovery_manager import DiscoveryManager
 from .emulator_scraper import EmulatorScraper
 from .scheduler import DiscoveryScheduler
@@ -13,6 +14,8 @@ from .web_scraper import WebScraper
 
 __all__ = [
     'ArxivAPISource',
+    'ArxivPlugin',
+    'plugin_registry',
     'DiscoveryManager',
     'DiscoveryScheduler',
     'EmulatorScraper',

--- a/src/thoth/discovery/api_sources.py
+++ b/src/thoth/discovery/api_sources.py
@@ -10,6 +10,7 @@ import urllib.parse
 from abc import ABC, abstractmethod
 from datetime import datetime
 from typing import Any
+import warnings
 
 import feedparser
 import httpx
@@ -410,11 +411,11 @@ class BaseAPISource(ABC):
 
 
 class ArxivAPISource(BaseAPISource):
-    """
-    ArXiv API source for discovering research papers.
+    """Deprecated ArXiv API source.
 
-    This class provides functionality to search ArXiv for papers based on
-    categories, keywords, and other criteria.
+    This class remains for backwards compatibility and will be removed in a
+    future release. Use :class:`thoth.discovery.plugins.arxiv_plugin.ArxivPlugin`
+    instead.
     """
 
     def __init__(self, rate_limit_delay: float = 3.0):
@@ -424,6 +425,12 @@ class ArxivAPISource(BaseAPISource):
         Args:
             rate_limit_delay: Delay between API requests in seconds.
         """
+        warnings.warn(
+            'ArxivAPISource is deprecated and will be removed in a future release. '
+            'Use ArxivPlugin instead.',
+            DeprecationWarning,
+            stacklevel=2,
+        )
         self.base_url = 'https://export.arxiv.org/api/query'
         self.rate_limit_delay = rate_limit_delay
         self.last_request_time = 0.0

--- a/src/thoth/discovery/plugins/__init__.py
+++ b/src/thoth/discovery/plugins/__init__.py
@@ -1,0 +1,12 @@
+from .base import BaseDiscoveryPlugin, DiscoveryPluginRegistry
+from .arxiv_plugin import ArxivPlugin
+
+plugin_registry = DiscoveryPluginRegistry()
+plugin_registry.register('arxiv', ArxivPlugin)
+
+__all__ = [
+    'ArxivPlugin',
+    'BaseDiscoveryPlugin',
+    'DiscoveryPluginRegistry',
+    'plugin_registry',
+]

--- a/src/thoth/discovery/plugins/arxiv_plugin.py
+++ b/src/thoth/discovery/plugins/arxiv_plugin.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import List
+
+from .base import BaseDiscoveryPlugin
+from ..api_sources import ArxivClient
+from thoth.utilities.schemas import ResearchQuery, ScrapedArticleMetadata
+
+
+class ArxivPlugin(BaseDiscoveryPlugin):
+    """Discovery plugin for searching arXiv."""
+
+    def __init__(self, config: dict | None = None) -> None:
+        super().__init__(config)
+        rate_limit = self.config.get('rate_limit_delay', 3.0)
+        self.client = ArxivClient(delay_seconds=rate_limit)
+
+    def discover(
+        self, query: ResearchQuery, max_results: int
+    ) -> List[ScrapedArticleMetadata]:
+        """Discover articles on arXiv for the given query."""
+        keywords = query.keywords or []
+        categories = self.config.get('categories', [])
+        sort_by = self.config.get('sort_by', 'lastUpdatedDate')
+        sort_order = self.config.get('sort_order', 'descending')
+
+        query_parts = []
+        if categories:
+            cat_queries = [f'cat:{c}' for c in categories]
+            query_parts.append('(' + ' OR '.join(cat_queries) + ')')
+        if keywords:
+            kw_queries = [f'(ti:"{k}" OR abs:"{k}")' for k in keywords]
+            query_parts.append('(' + ' OR '.join(kw_queries) + ')')
+        search_query = ' AND '.join(query_parts) if query_parts else 'cat:cs.*'
+
+        papers = self.client.search(
+            search_query,
+            start=0,
+            max_results=min(max_results, 1000),
+            sort_by=sort_by,
+            sort_order=sort_order,
+        )
+
+        results: List[ScrapedArticleMetadata] = []
+        for paper in papers:
+            metadata = ScrapedArticleMetadata(
+                title=paper.title,
+                authors=paper.authors,
+                abstract=paper.abstract,
+                publication_date=paper.published,
+                journal='arXiv',
+                doi=paper.doi,
+                arxiv_id=paper.id,
+                url=f'https://arxiv.org/abs/{paper.id}',
+                pdf_url=paper.pdf_url,
+                keywords=paper.categories,
+                source='arxiv',
+                scrape_timestamp=datetime.now().isoformat(),
+                additional_metadata={
+                    'categories': paper.categories,
+                    'updated': paper.updated,
+                    'comment': paper.comment,
+                    'journal_ref': paper.journal_ref,
+                    'citation_count': paper.citation_count,
+                },
+            )
+            results.append(metadata)
+        return results

--- a/src/thoth/services/discovery_service.py
+++ b/src/thoth/services/discovery_service.py
@@ -14,7 +14,9 @@ from typing import Any
 
 import requests
 
-from thoth.discovery.api_sources import ArxivAPISource, PubMedAPISource
+from thoth.discovery.api_sources import PubMedAPISource
+from thoth.discovery.plugins import ArxivPlugin, plugin_registry
+from thoth.discovery.plugins.base import DiscoveryPluginRegistry
 from thoth.discovery.emulator_scraper import EmulatorScraper
 from thoth.discovery.web_scraper import WebScraper
 from thoth.services.article_service import ArticleService
@@ -24,6 +26,7 @@ from thoth.utilities.schemas import (
     DiscoveryResult,
     DiscoverySource,
     ScheduleConfig,
+    ResearchQuery,
     ScrapedArticleMetadata,
 )
 
@@ -63,11 +66,13 @@ class DiscoveryService(BaseService):
         self.results_dir = Path(results_dir or self.config.discovery_results_dir)
         self.results_dir.mkdir(parents=True, exist_ok=True)
 
-        # Initialize API sources
+        # Initialize API sources and plugin registry
         self.api_sources = {
-            'arxiv': ArxivAPISource(),
             'pubmed': PubMedAPISource(),
         }
+        self.plugin_registry: DiscoveryPluginRegistry = plugin_registry
+        if 'arxiv' not in self.plugin_registry.list_plugins():
+            self.plugin_registry.register('arxiv', ArxivPlugin)
 
         # Initialize web scraper
         self.web_scraper = WebScraper()
@@ -339,9 +344,20 @@ class DiscoveryService(BaseService):
 
         try:
             if source.source_type == 'api' and source.api_config:
-                # Use API source
                 source_type = source.api_config.get('source')
-                if source_type in self.api_sources:
+                if self.plugin_registry.get(source_type):
+                    plugin = self.plugin_registry.create(
+                        source_type, config=source.api_config
+                    )
+                    dummy_query = ResearchQuery(
+                        name=source.name,
+                        description=source.description,
+                        research_question=source.description,
+                        keywords=source.api_config.get('keywords', []),
+                    )
+                    default_max = source.schedule_config.max_articles_per_run
+                    articles = plugin.discover(dummy_query, max_articles or default_max)
+                elif source_type in self.api_sources:
                     api_source = self.api_sources[source_type]
                     default_max = source.schedule_config.max_articles_per_run
                     articles = api_source.search(

--- a/tests/discovery/plugins/test_arxiv_plugin.py
+++ b/tests/discovery/plugins/test_arxiv_plugin.py
@@ -1,0 +1,56 @@
+from unittest.mock import patch
+
+import pytest
+
+from thoth.discovery.plugins.arxiv_plugin import ArxivPlugin
+from thoth.discovery.plugins.base import DiscoveryPluginRegistry
+from thoth.utilities.schemas import ResearchQuery, ScrapedArticleMetadata
+from thoth.utilities.schemas.citations import ArxivPaper
+
+
+def sample_query():
+    return ResearchQuery(
+        name='test',
+        description='d',
+        research_question='rq',
+        keywords=['ml'],
+    )
+
+
+def make_paper():
+    return ArxivPaper(
+        id='1234.56789',
+        title='Test Paper',
+        authors=['Alice'],
+        abstract='About ML',
+        categories=['cs.LG'],
+        pdf_url='https://arxiv.org/pdf/1234.56789.pdf',
+        published='2024-01-01',
+        updated='2024-01-02',
+    )
+
+
+def test_arxiv_plugin_discover():
+    query = sample_query()
+    paper = make_paper()
+    with patch('thoth.discovery.plugins.arxiv_plugin.ArxivClient') as MockClient:
+        instance = MockClient.return_value
+        instance.search.return_value = [paper]
+
+        plugin = ArxivPlugin(config={'categories': ['cs.LG']})
+        results = plugin.discover(query, max_results=5)
+
+        assert len(results) == 1
+        result = results[0]
+        assert result.title == paper.title
+        assert result.arxiv_id == paper.id
+        assert result.source == 'arxiv'
+        instance.search.assert_called_once()
+
+
+def test_plugin_registry_registration():
+    registry = DiscoveryPluginRegistry()
+    registry.register('arxiv', ArxivPlugin)
+    assert 'arxiv' in registry.list_plugins()
+    plugin = registry.create('arxiv', config={})
+    assert isinstance(plugin, ArxivPlugin)


### PR DESCRIPTION
## Summary
- implement `ArxivPlugin` discovery plugin
- register plugin via `plugin_registry`
- wire plugin registry into `DiscoveryService`
- deprecate `ArxivAPISource`
- add tests for the new plugin and integration with `DiscoveryService`

## Testing
- `pre-commit run ruff-format --files src/thoth/discovery/plugins/arxiv_plugin.py src/thoth/discovery/plugins/__init__.py src/thoth/discovery/__init__.py src/thoth/discovery/api_sources.py src/thoth/services/discovery_service.py tests/discovery/plugins/test_arxiv_plugin.py tests/test_discovery/test_discovery_service_plugin.py`
- `pytest tests/discovery/plugins/test_arxiv_plugin.py tests/test_discovery/test_discovery_service_plugin.py -q` *(fails: Coverage failure)*

------
https://chatgpt.com/codex/tasks/task_e_684ce6e7b2a48324b0441fb5fe7c111f